### PR TITLE
feat(gnu): add version string comparison algorithm

### DIFF
--- a/x/gnu/sort.go
+++ b/x/gnu/sort.go
@@ -1,0 +1,121 @@
+package gnu
+
+/* Compare file names containing version numbers.
+
+   Copyright (C) 1995 Ian Jackson <iwj10@cus.cam.ac.uk>
+   Copyright (C) 2001 Anthony Towns <aj@azure.humbug.org.au>
+   Copyright (C) 2008-2025 Free Software Foundation, Inc.
+
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+// Compare compares two version strings and returns:
+// -1 if a < b
+//
+//	0 if a == b
+//	1 if a > b
+func Compare(a, b string) int {
+	return verrevcmp([]byte(a), []byte(b))
+}
+
+// verrevcmp implements version number comparison algorithm (similar to GNU strverscmp)
+// Compares character and numeric segments separately, with numeric segments compared by value
+func verrevcmp(s1, s2 []byte) int {
+	s1Len := len(s1)
+	s2Len := len(s2)
+	s1Pos := 0
+	s2Pos := 0
+
+	for s1Pos < s1Len || s2Pos < s2Len {
+		first_diff := 0
+
+		// Compare non-digit portions
+		for (s1Pos < s1Len && !isDigit(s1[s1Pos])) || (s2Pos < s2Len && !isDigit(s2[s2Pos])) {
+			var s1c byte
+			var s2c byte
+
+			if s1Pos < s1Len {
+				s1c = s1[s1Pos]
+			}
+			if s2Pos < s2Len {
+				s2c = s2[s2Pos]
+			}
+
+			s1Order := order(s1c)
+			s2Order := order(s2c)
+
+			if s1Order != s2Order {
+				return s1Order - s2Order
+			}
+
+			s1Pos++
+			s2Pos++
+		}
+
+		// Skip leading zeros
+		for s1Pos < s1Len && s1[s1Pos] == '0' {
+			s1Pos++
+		}
+		for s2Pos < s2Len && s2[s2Pos] == '0' {
+			s2Pos++
+		}
+
+		// Compare numeric portions
+		for s1Pos < s1Len && s2Pos < s2Len && isDigit(s1[s1Pos]) && isDigit(s2[s2Pos]) {
+			if first_diff == 0 {
+				first_diff = int(s1[s1Pos]) - int(s2[s2Pos])
+			}
+			s1Pos++
+			s2Pos++
+		}
+
+		// If one numeric segment is longer, that number is larger
+		if s1Pos < s1Len && isDigit(s1[s1Pos]) {
+			return 1
+		}
+		if s2Pos < s2Len && isDigit(s2[s2Pos]) {
+			return -1
+		}
+		if first_diff != 0 {
+			return first_diff
+		}
+	}
+
+	return 0
+}
+
+// order returns the sorting priority of a character
+// digits: 0, letters: ASCII value, '~': -1, null: 0, others: ASCII value + 256
+func order(c byte) int {
+	if isDigit(c) {
+		return 0
+	} else if isAlpha(c) {
+		return int(c)
+	} else if c == '~' {
+		return -1
+	} else if c == 0 {
+		return 0
+	} else {
+		return int(c) + 256
+	}
+}
+
+// isDigit checks if the character is a digit
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+// isAlpha checks if the character is a letter
+func isAlpha(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}

--- a/x/gnu/sort_test.go
+++ b/x/gnu/sort_test.go
@@ -1,0 +1,189 @@
+package gnu
+
+import (
+	"testing"
+)
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		// Basic version comparisons
+		{"1.0", "2.0", -1},
+		{"2.0", "1.0", 1},
+		{"1.0", "1.0", 0},
+
+		// Multi-part versions
+		{"1.0.0", "1.0.1", -1},
+		{"1.0.1", "1.0.0", 1},
+		{"1.0.0", "1.0.0", 0},
+		{"1.2.3", "1.2.4", -1},
+		{"1.2.10", "1.2.9", 1},
+
+		// Numeric comparison (not lexicographic)
+		{"1.10", "1.9", 1},
+		{"1.2", "1.10", -1},
+		{"10", "9", 1},
+		{"2", "10", -1},
+
+		// Leading zeros
+		{"1.01", "1.1", 0},
+		{"1.001", "1.1", 0},
+		{"01", "1", 0},
+		{"001", "01", 0},
+
+		// Empty strings
+		{"", "", 0},
+		{"1", "", 1},
+		{"", "1", -1},
+
+		// Tilde (sorts before everything, including empty)
+		{"1.0~rc1", "1.0", -1},
+		{"1.0~", "1.0", -1},
+		{"1.0~alpha", "1.0~beta", -1},
+		{"~", "", -1},
+
+		// Letters vs numbers
+		{"a", "1", 1},
+		{"1a", "1b", -1},
+		{"1.0a", "1.0b", -1},
+		{"1.0a", "1.0", 1},
+
+		// Complex version strings
+		{"1.0alpha", "1.0beta", -1},
+		{"1.0alpha1", "1.0alpha2", -1},
+		{"1.0.0-rc1", "1.0.0-rc2", -1},
+		{"1.0.0-rc10", "1.0.0-rc9", 1},
+
+		// Real-world examples
+		{"2.6.32", "2.6.32.1", -1},
+		{"3.0", "2.6.39", 1},
+		{"0.9.9", "1.0.0", -1},
+
+		// With prefixes
+		{"v1.0.0", "v1.0.1", -1},
+		{"v2.0", "v10.0", -1},
+		{"release-1.0", "release-2.0", -1},
+
+		// Edge cases with special characters
+		{"1.0.0", "1.0.0.0", -1},
+		{"1-2", "1.2", -1}, // '-' (45+256=301) vs '.' (46+256=302)
+		{"1_2", "1.2", 1},  // '_' (95+256=351) vs '.' (46+256=302)
+
+		// Debian-style versions
+		{"1.0+git20200101", "1.0+git20200102", -1},
+		{"1.0~git20200101", "1.0", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			got := Compare(tt.a, tt.b)
+			// Normalize to -1, 0, 1
+			if got < 0 {
+				got = -1
+			} else if got > 0 {
+				got = 1
+			}
+			if got != tt.want {
+				t.Errorf("Compare(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareSymmetry(t *testing.T) {
+	pairs := [][2]string{
+		{"1.0", "2.0"},
+		{"1.10", "1.9"},
+		{"1.0~rc1", "1.0"},
+		{"a", "b"},
+		{"1.0alpha", "1.0beta"},
+	}
+
+	for _, pair := range pairs {
+		a, b := pair[0], pair[1]
+		ab := Compare(a, b)
+		ba := Compare(b, a)
+
+		// Normalize
+		if ab < 0 {
+			ab = -1
+		} else if ab > 0 {
+			ab = 1
+		}
+		if ba < 0 {
+			ba = -1
+		} else if ba > 0 {
+			ba = 1
+		}
+
+		if ab != -ba {
+			t.Errorf("Symmetry violated: Compare(%q, %q)=%d, Compare(%q, %q)=%d", a, b, ab, b, a, ba)
+		}
+	}
+}
+
+func TestCompareReflexive(t *testing.T) {
+	versions := []string{
+		"",
+		"0",
+		"1",
+		"1.0",
+		"1.0.0",
+		"1.0~rc1",
+		"1.0alpha",
+		"v2.0.0",
+	}
+
+	for _, v := range versions {
+		if got := Compare(v, v); got != 0 {
+			t.Errorf("Compare(%q, %q) = %d, want 0", v, v, got)
+		}
+	}
+}
+
+func TestOrder(t *testing.T) {
+	tests := []struct {
+		c    byte
+		want int
+	}{
+		{'0', 0},
+		{'9', 0},
+		{'a', int('a')},
+		{'z', int('z')},
+		{'A', int('A')},
+		{'Z', int('Z')},
+		{'~', -1},
+		{0, 0},
+		{'.', int('.') + 256},
+		{'-', int('-') + 256},
+		{'_', int('_') + 256},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.c), func(t *testing.T) {
+			if got := order(tt.c); got != tt.want {
+				t.Errorf("order(%q) = %d, want %d", tt.c, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDigit(t *testing.T) {
+	for c := byte(0); c < 128; c++ {
+		want := c >= '0' && c <= '9'
+		if got := isDigit(c); got != want {
+			t.Errorf("isDigit(%q) = %v, want %v", c, got, want)
+		}
+	}
+}
+
+func TestIsAlpha(t *testing.T) {
+	for c := byte(0); c < 128; c++ {
+		want := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+		if got := isAlpha(c); got != want {
+			t.Errorf("isAlpha(%q) = %v, want %v", c, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Implement GNU-style version comparison (strverscmp) for sorting version strings naturally. The algorithm:
- Compares numeric segments by value, not lexicographically
- Handles leading zeros correctly
- Supports tilde (~) prefix sorting (sorts before empty)
- Maintains proper ordering of letters vs special characters

Includes comprehensive test suite covering edge cases like multi-part versions, alphanumeric strings, and real-world examples.