### PR TITLE
ci: add GitHub Actions workflow for Go testing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,35 @@
+name: Test
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.22.x
+          - 1.23.x
+          - 1.24.x
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{matrix.go}}
+      - name: Download Go modules
+        run: go mod download
+      - name: Test Go code
+        run: go test -v -race -covermode atomic -coverprofile coverage.out ./...
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          disable_search: true
+          files: coverage.out


### PR DESCRIPTION
- Configure test workflow to run on push and pull requests
- Set up test matrix for Go versions 1.22.x, 1.23.x, and 1.24.x
- Enable race detection and code coverage reporting
- Integrate Codecov for coverage uploads