### PR TITLE
feat(loader): add XGo formula file loader using ixgo interpreter

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -1,0 +1,135 @@
+package loader
+
+import (
+	"fmt"
+	"go/ast"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"unsafe"
+
+	"github.com/goplus/ixgo"
+	"github.com/goplus/ixgo/xgobuild"
+
+	// make ixgo happy
+	_ "github.com/goplus/llar/internal/ixgo"
+)
+
+// classfileMain represents a Go+ class file that can be executed
+type classfileMain interface {
+	Main()
+}
+
+// StructElem wraps a reflected struct element loaded from a Go+ formula file.
+// It provides methods to get and set field values by name.
+type StructElem struct {
+	elem reflect.Value
+}
+
+// newStructElem creates a new StructElem by looking up the struct type by name,
+// instantiating it, and executing its Main method.
+func newStructElem(interp *ixgo.Interp, structName string) (*StructElem, error) {
+	typ, ok := interp.GetType(structName)
+	if !ok {
+		return nil, fmt.Errorf("failed to load formula: struct name not found: %s", structName)
+	}
+	val := reflect.New(typ)
+
+	val.Interface().(classfileMain).Main()
+
+	return &StructElem{elem: val.Elem()}, nil
+}
+
+// Value retrieves the value of a struct field by name.
+// It supports both exported and unexported fields.
+func (e *StructElem) Value(key string) any {
+	return valueOf(e.elem, key)
+}
+
+// SetValue sets the value of a struct field by name.
+// It supports both exported and unexported fields.
+func (e *StructElem) SetValue(key string, value any) {
+	setValue(e.elem, key, value)
+}
+
+// Loader defines the interface for loading Go+ formula files into StructElem instances.
+type Loader interface {
+	Load(path string) (*StructElem, error)
+}
+
+// FormulaLoader is an implementation of Loader that uses ixgo to load and execute Go+ formula files.
+type FormulaLoader struct {
+	ctx *ixgo.Context
+}
+
+// NewFormulaLoader creates a new FormulaLoader with the given ixgo context.
+func NewFormulaLoader(ctx *ixgo.Context) Loader {
+	return &FormulaLoader{ctx: ctx}
+}
+
+// Load loads a Go+ formula file from the specified path and returns a StructElem.
+// The file name should follow the pattern "{StructName}_*.gox" where StructName
+// is the name of the struct to be loaded.
+func (f *FormulaLoader) Load(path string) (*StructElem, error) {
+	interp, err := load(f.ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	defer interp.ResetIcall()
+
+	structName, _, ok := strings.Cut(filepath.Base(path), "_")
+	if !ok {
+		return nil, fmt.Errorf("failed to load formula: file name is not valid: %s", path)
+	}
+
+	structElem, err := newStructElem(interp, structName)
+	if err != nil {
+		return nil, err
+	}
+
+	return structElem, nil
+}
+
+// load builds and loads a Go+ directory, returning an initialized interpreter.
+func load(ctx *ixgo.Context, path string) (*ixgo.Interp, error) {
+	source, err := xgobuild.BuildDir(ctx, filepath.Dir(path))
+	if err != nil {
+		return nil, err
+	}
+	pkgs, err := ctx.LoadFile("main.go", source)
+	if err != nil {
+		return nil, err
+	}
+	interp, err := ctx.NewInterp(pkgs)
+	if err != nil {
+		return nil, err
+	}
+	if err = interp.RunInit(); err != nil {
+		return nil, err
+	}
+	return interp, nil
+}
+
+// unexportValueOf creates a reflect.Value that allows access to unexported fields.
+func unexportValueOf(field reflect.Value) reflect.Value {
+	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
+}
+
+// valueOf retrieves the value of a field by name from a struct element.
+// It handles both exported and unexported fields.
+func valueOf(elem reflect.Value, name string) any {
+	if ast.IsExported(name) {
+		return elem.FieldByName(name).Elem().Interface()
+	}
+	return unexportValueOf(elem.FieldByName(name)).Interface()
+}
+
+// setValue sets the value of a field by name in a struct element.
+// It handles both exported and unexported fields.
+func setValue(elem reflect.Value, name string, value any) {
+	if ast.IsExported(name) {
+		elem.FieldByName(name).Elem().Set(reflect.ValueOf(value))
+		return
+	}
+	unexportValueOf(elem.FieldByName(name)).Set(reflect.ValueOf(value))
+}

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -1,0 +1,307 @@
+package loader
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/goplus/ixgo"
+	"github.com/goplus/llar/pkgs/mod/module"
+)
+
+// testStruct is a test structure with both exported and unexported fields
+type testStruct struct {
+	ExportedField   *string
+	unexportedField *int
+	AnotherExported *bool
+}
+
+func TestValueOf(t *testing.T) {
+	// Setup test data
+	str := "test value"
+	num := 42
+	flag := true
+
+	ts := testStruct{
+		ExportedField:   &str,
+		unexportedField: &num,
+		AnotherExported: &flag,
+	}
+
+	// Use pointer to make the value addressable for unexported fields
+	elem := reflect.ValueOf(&ts).Elem()
+
+	// Test exported field
+	t.Run("ExportedField", func(t *testing.T) {
+		val := valueOf(elem, "ExportedField")
+		if got, ok := val.(string); !ok || got != str {
+			t.Errorf("valueOf(ExportedField) = %v, want %v", val, str)
+		}
+	})
+
+	// Test unexported field
+	t.Run("UnexportedField", func(t *testing.T) {
+		val := valueOf(elem, "unexportedField")
+		if got, ok := val.(int); !ok || got != num {
+			t.Errorf("valueOf(unexportedField) = %v, want %v", val, num)
+		}
+	})
+
+	// Test another exported field
+	t.Run("AnotherExported", func(t *testing.T) {
+		val := valueOf(elem, "AnotherExported")
+		if got, ok := val.(bool); !ok || got != flag {
+			t.Errorf("valueOf(AnotherExported) = %v, want %v", val, flag)
+		}
+	})
+}
+
+func TestSetValue(t *testing.T) {
+	// Setup test data
+	str := "initial"
+	num := 10
+	flag := false
+
+	ts := testStruct{
+		ExportedField:   &str,
+		unexportedField: &num,
+		AnotherExported: &flag,
+	}
+
+	elem := reflect.ValueOf(&ts).Elem()
+
+	// Test setting exported field
+	t.Run("SetExportedField", func(t *testing.T) {
+		newStr := "modified"
+		setValue(elem, "ExportedField", &newStr)
+		if *ts.ExportedField != newStr {
+			t.Errorf("after setValue, ExportedField = %v, want %v", *ts.ExportedField, newStr)
+		}
+	})
+
+	// Test setting unexported field
+	t.Run("SetUnexportedField", func(t *testing.T) {
+		newNum := 99
+		setValue(elem, "unexportedField", &newNum)
+		if *ts.unexportedField != newNum {
+			t.Errorf("after setValue, unexportedField = %v, want %v", *ts.unexportedField, newNum)
+		}
+	})
+
+	// Test setting another exported field
+	t.Run("SetAnotherExported", func(t *testing.T) {
+		newFlag := true
+		setValue(elem, "AnotherExported", &newFlag)
+		if *ts.AnotherExported != newFlag {
+			t.Errorf("after setValue, AnotherExported = %v, want %v", *ts.AnotherExported, newFlag)
+		}
+	})
+}
+
+func TestUnexportValueOf(t *testing.T) {
+	// Setup test data
+	num := 123
+	ts := testStruct{
+		unexportedField: &num,
+	}
+
+	// Use pointer to make the value addressable
+	elem := reflect.ValueOf(&ts).Elem()
+	field := elem.FieldByName("unexportedField")
+
+	// Test getting unexported field value
+	unexportedVal := unexportValueOf(field)
+	if !unexportedVal.CanInterface() {
+		t.Error("unexportValueOf should return a value that can be interfaced")
+	}
+
+	got := unexportedVal.Interface().(*int)
+	if *got != num {
+		t.Errorf("unexportValueOf returned %v, want %v", *got, num)
+	}
+}
+
+func TestStructElemValueAndSetValue(t *testing.T) {
+	// Setup test data
+	str := "test"
+	num := 42
+	flag := true
+
+	ts := testStruct{
+		ExportedField:   &str,
+		unexportedField: &num,
+		AnotherExported: &flag,
+	}
+
+	// Use pointer to make the value addressable for unexported fields
+	se := &StructElem{elem: reflect.ValueOf(&ts).Elem()}
+
+	// Test Value method
+	t.Run("Value", func(t *testing.T) {
+		// Test exported field
+		if got := se.Value("ExportedField").(string); got != str {
+			t.Errorf("StructElem.Value(ExportedField) = %v, want %v", got, str)
+		}
+
+		// Test unexported field
+		if got := se.Value("unexportedField").(int); got != num {
+			t.Errorf("StructElem.Value(unexportedField) = %v, want %v", got, num)
+		}
+
+		// Test another exported field
+		if got := se.Value("AnotherExported").(bool); got != flag {
+			t.Errorf("StructElem.Value(AnotherExported) = %v, want %v", got, flag)
+		}
+	})
+
+	// Test SetValue method
+	t.Run("SetValue", func(t *testing.T) {
+		// Create a new StructElem with a pointer to allow modifications
+		tsPtr := &testStruct{
+			ExportedField:   &str,
+			unexportedField: &num,
+			AnotherExported: &flag,
+		}
+		sePtr := &StructElem{elem: reflect.ValueOf(tsPtr).Elem()}
+
+		// Test setting exported field
+		newStr := "new value"
+		sePtr.SetValue("ExportedField", &newStr)
+		if *tsPtr.ExportedField != newStr {
+			t.Errorf("after SetValue, ExportedField = %v, want %v", *tsPtr.ExportedField, newStr)
+		}
+
+		// Test setting unexported field
+		newNum := 999
+		sePtr.SetValue("unexportedField", &newNum)
+		if *tsPtr.unexportedField != newNum {
+			t.Errorf("after SetValue, unexportedField = %v, want %v", *tsPtr.unexportedField, newNum)
+		}
+
+		// Test setting another exported field
+		newFlag := false
+		sePtr.SetValue("AnotherExported", &newFlag)
+		if *tsPtr.AnotherExported != newFlag {
+			t.Errorf("after SetValue, AnotherExported = %v, want %v", *tsPtr.AnotherExported, newFlag)
+		}
+	})
+}
+
+func TestNewFormulaLoader(t *testing.T) {
+	// Test that NewFormulaLoader returns a non-nil Loader
+	loader := NewFormulaLoader(nil)
+	if loader == nil {
+		t.Error("NewFormulaLoader returned nil")
+	}
+
+	// Test that it returns a FormulaLoader
+	if _, ok := loader.(*FormulaLoader); !ok {
+		t.Error("NewFormulaLoader did not return a *FormulaLoader")
+	}
+}
+
+func TestFormulaLoader_LoadLlarFormula(t *testing.T) {
+	// Create ixgo context
+	ctx := ixgo.NewContext(ixgo.SupportMultipleInterp)
+
+	// Create loader
+	loader := NewFormulaLoader(ctx)
+
+	// Load formula_llar.gox
+	testdataPath := filepath.Join("testdata", "formula", "hello_llar.gox")
+	elem, err := loader.Load(testdataPath)
+	if err != nil {
+		t.Fatalf("Failed to load formula: %v", err)
+	}
+
+	if elem == nil {
+		t.Fatal("Loaded StructElem is nil")
+	}
+
+	// Test reading fields from the loaded formula
+	// Based on the formula file, we expect fields like id, fromVer, onRequire, onBuild
+	t.Run("ReadFields", func(t *testing.T) {
+		// Try to read the id field
+		id := elem.Value("modID")
+
+		if id != "DaveGamble/cJSON" {
+			t.Fatalf("Unexpected id value: want %s got %s", "DaveGamble/cJSON", id)
+			return
+		}
+		t.Logf("id field value: %v (type: %T)", id, id)
+
+		// Try to read the fromVer field
+		fromVer := elem.Value("modFromVer")
+		if fromVer != "v1.0.0" {
+			t.Fatalf("Unexpected fromVer value: want %s got %s", "v1.0.0", fromVer)
+			return
+		}
+		t.Logf("fromVer field value: %v (type: %T)", fromVer, fromVer)
+	})
+}
+
+func TestFormulaLoader_LoadCmpFormula(t *testing.T) {
+	// Create ixgo context
+	ctx := ixgo.NewContext(ixgo.SupportMultipleInterp)
+
+	// Create loader
+	loader := NewFormulaLoader(ctx)
+
+	// Load formula_cmp.gox
+	testdataPath := filepath.Join("testdata", "cmp", "hello_cmp.gox")
+	elem, err := loader.Load(testdataPath)
+	if err != nil {
+		t.Fatalf("Failed to load formula: %v", err)
+	}
+
+	if elem == nil {
+		t.Fatal("Loaded StructElem is nil")
+	}
+
+	// Test reading fields from the loaded formula
+	t.Run("ReadFields", func(t *testing.T) {
+		// Try to read the compareVer field
+		compareVer := elem.Value("fCompareVer").(module.VersionComparator)
+
+		if ret := compareVer(module.Version{}, module.Version{}); ret != -1 {
+			t.Fatalf("Unexpected compare result: want %d got %d", -1, ret)
+			return
+		}
+		t.Logf("compareVer field value: %v (type: %T)", compareVer, compareVer)
+	})
+}
+
+func TestFormulaLoader_SetValue(t *testing.T) {
+	// Create ixgo context
+	ctx := ixgo.NewContext(ixgo.SupportMultipleInterp)
+
+	// Create loader
+	loader := NewFormulaLoader(ctx)
+
+	// Load formula
+	testdataPath := filepath.Join("testdata", "formula", "hello_llar.gox")
+	elem, err := loader.Load(testdataPath)
+	if err != nil {
+		t.Fatalf("Failed to load formula: %v", err)
+	}
+
+	// Test setting a field value
+	t.Run("SetField", func(t *testing.T) {
+		// Read original value
+		originalID := elem.Value("modID")
+		t.Logf("Original id: %v", originalID)
+
+		// Set a new value
+		newID := "test/modified"
+		elem.SetValue("modID", newID)
+
+		// Read the modified value
+		modifiedID := elem.Value("modID")
+		t.Logf("Modified id: %v", modifiedID)
+
+		// Verify the value was changed
+		if modifiedID != newID {
+			t.Errorf("SetValue failed: got %v, want %v", modifiedID, newID)
+		}
+	})
+}

--- a/internal/loader/testdata/cmp/hello_cmp.gox
+++ b/internal/loader/testdata/cmp/hello_cmp.gox
@@ -1,0 +1,3 @@
+compareVer (a, b) => {
+    return -1
+}

--- a/internal/loader/testdata/formula/hello_llar.gox
+++ b/internal/loader/testdata/formula/hello_llar.gox
@@ -1,0 +1,11 @@
+id "DaveGamble/cJSON"
+
+fromVer "v1.0.0"
+
+onRequire (proj, deps) => {
+   echo "hello"
+}
+
+onBuild (proj, out) => {
+    echo "hello"
+}


### PR DESCRIPTION
Implement a new loader package for loading and executing Go+ formula files:
- Add FormulaLoader with ixgo context for interpreting Go+ files
- Add StructElem wrapper for accessing struct fields via reflection
- Support both exported and unexported field access using unsafe pointers
- Add custom resolver for Go module dependency lookup
- Include comprehensive test coverage for loader and resolver