### PR TITLE
feat(cmp): add CmpApp module for version comparison

### DIFF
--- a/cmp/cmp.go
+++ b/cmp/cmp.go
@@ -1,6 +1,6 @@
 package cmp
 
-import "github.com/goplus/llar/pkgs/mod/module"
+import "github.com/goplus/llar/mod/module"
 
 const GopPackage = true
 
@@ -8,10 +8,13 @@ type CmpApp struct {
 	fCompareVer func(a, b module.Version) int
 }
 
+// The provided function fn will be used to compare version strings
+// when resolving dependencies for those versions which are not in Debian-style.
 func (f *CmpApp) CompareVer(fn func(a, b module.Version) int) {
 	f.fCompareVer = fn
 }
 
+// Gopt_CmpApp_Main is main entry of this classfile.
 func Gopt_CmpApp_Main(this interface{ MainEntry() }) {
 	this.MainEntry()
 }


### PR DESCRIPTION
This change introduces a new base class **CmpApp** in `_cmp.gox`, which serves as a common foundation for comparison-related logic.

In addition, it allows users to provide custom comparison functions to flexibly control comparison behavior. This makes it possible to define domain-specific comparison rules without being tied to a fixed implementation.

For example, users can define a custom comparator to compare versions:

```go
compareVer(a, b) => {
    return semver.Compare(a.Version, b.Version)
}
```

This design improves extensibility and keeps comparison logic explicit and customizable.
