### PR TITLE
feat(vcs): add version control system abstraction layer

### DIFF
--- a/internal/vcs/client.go
+++ b/internal/vcs/client.go
@@ -1,0 +1,39 @@
+// Copyright 2024 The llar Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+)
+
+// client defines the internal interface for interacting with code hosting platforms.
+type client interface {
+	// Tags returns all tags from the repository.
+	Tags(ctx context.Context, owner, repo string) ([]string, error)
+
+	// Latest returns the latest commit hash on the default branch.
+	Latest(ctx context.Context, owner, repo string) (string, error)
+
+	// Stat returns file info for the given path.
+	Stat(ctx context.Context, owner, repo, ref, path string) (fs.FileInfo, error)
+
+	// ReadFile reads the content of a file.
+	ReadFile(ctx context.Context, owner, repo, ref, path string) ([]byte, error)
+
+	// SyncDir downloads a directory to the destination directory.
+	SyncDir(ctx context.Context, owner, repo, ref, path, destDir string) error
+}
+
+// newClient creates a client for the specified host.
+func newClient(host string) (client, error) {
+	switch host {
+	case "github.com":
+		return newGitHubClient(), nil
+	default:
+		return nil, fmt.Errorf("unsupported host: %s", host)
+	}
+}

--- a/internal/vcs/github.go
+++ b/internal/vcs/github.go
@@ -1,0 +1,272 @@
+// Copyright 2024 The llar Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// githubClient implements client interface using raw GitHub URLs (no API).
+type githubClient struct {
+	httpClient *http.Client
+}
+
+// newGitHubClient creates a new GitHub client.
+func newGitHubClient() *githubClient {
+	return &githubClient{
+		httpClient: &http.Client{
+			Timeout: 60 * time.Second,
+		},
+	}
+}
+
+// Tags returns all tags from the repository using git ls-remote.
+func (g *githubClient) Tags(ctx context.Context, owner, repo string) ([]string, error) {
+	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--tags", "--refs", repoURL)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git ls-remote: %w", err)
+	}
+
+	var tags []string
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		// Format: <sha>\trefs/tags/<tagname>
+		parts := strings.Split(line, "\t")
+		if len(parts) != 2 {
+			continue
+		}
+		ref := parts[1]
+		tag := strings.TrimPrefix(ref, "refs/tags/")
+		tags = append(tags, tag)
+	}
+
+	return tags, nil
+}
+
+// Latest returns the latest commit hash on the default branch using git ls-remote.
+func (g *githubClient) Latest(ctx context.Context, owner, repo string) (string, error) {
+	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", repoURL, "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git ls-remote: %w", err)
+	}
+
+	line := strings.TrimSpace(string(output))
+	if line == "" {
+		return "", fmt.Errorf("no HEAD ref found")
+	}
+
+	// Format: <sha>\tHEAD
+	parts := strings.Split(line, "\t")
+	if len(parts) < 1 {
+		return "", fmt.Errorf("invalid ls-remote output: %s", line)
+	}
+
+	return parts[0], nil
+}
+
+// Stat returns file info for the given path using HEAD request.
+func (g *githubClient) Stat(ctx context.Context, owner, repo, ref, path string) (fs.FileInfo, error) {
+	// Try as file first
+	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", owner, repo, ref, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		// It's a file
+		size := resp.ContentLength
+		if size < 0 {
+			size = 0
+		}
+		return &fileInfo{
+			name:  filepath.Base(path),
+			size:  size,
+			mode:  0644,
+			isDir: false,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+}
+
+// ReadFile reads the content of a file using raw.githubusercontent.com.
+func (g *githubClient) ReadFile(ctx context.Context, owner, repo, ref, path string) ([]byte, error) {
+	url := fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", owner, repo, ref, path)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("file not found: %s", path)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d for %s", resp.StatusCode, path)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// SyncDir downloads a directory to the destination directory using git sparse-checkout.
+// This is more efficient than tarball for large repositories when only a subdirectory is needed.
+// Falls back to tarball method if sparse-checkout fails.
+func (g *githubClient) SyncDir(ctx context.Context, owner, repo, ref, path, destDir string) error {
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return err
+	}
+
+	// Normalize path
+	path = filepath.Clean(path)
+	if path == "." {
+		path = ""
+	}
+
+	// Try sparse-checkout first (more efficient for subdirectories)
+	if path != "" {
+		err := g.syncDirSparse(ctx, owner, repo, ref, path, destDir)
+		if err == nil {
+			return nil
+		}
+		// Fall back to tarball if sparse-checkout fails
+	}
+
+	// Use shallow clone for root directory or as fallback
+	return g.syncDirShallowClone(ctx, owner, repo, ref, destDir)
+}
+
+// syncDirSparse uses git sparse-checkout to download only the specified directory.
+// This is much more efficient for large repositories.
+// If the directory already contains a git repo, it will fetch and update instead of re-cloning.
+func (g *githubClient) syncDirSparse(ctx context.Context, owner, repo, ref, path, destDir string) error {
+	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+
+	// Helper to run git commands in destDir
+	runGit := func(args ...string) error {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = destDir
+		cmd.Env = append(os.Environ(),
+			"GIT_TERMINAL_PROMPT=0", // Disable interactive prompts
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git %s: %w\n%s", args[0], err, string(output))
+		}
+		return nil
+	}
+
+	// Initialize git repository (ignore error if already initialized)
+	runGit("init")
+
+	// Add remote (ignore error if already exists)
+	runGit("remote", "add", "origin", repoURL)
+
+	// Enable sparse-checkout (no-cone mode for exact directory matching)
+	if err := runGit("sparse-checkout", "init", "--no-cone"); err != nil {
+		return err
+	}
+
+	// Set the sparse-checkout pattern to match only the specified directory
+	gitPath := filepath.ToSlash(path)
+	if err := runGit("sparse-checkout", "set", gitPath+"/**"); err != nil {
+		return err
+	}
+
+	// Fetch the specified ref
+	if err := runGit("fetch", "--depth=1", "--filter=blob:none", "origin", ref); err != nil {
+		return err
+	}
+
+	// Checkout the fetched content
+	if err := runGit("checkout", "FETCH_HEAD"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// syncDirShallowClone uses git init + fetch + checkout to download the repository.
+// Used for root directory sync or as fallback when sparse-checkout fails.
+// Works with empty, non-empty, or existing git directories.
+func (g *githubClient) syncDirShallowClone(ctx context.Context, owner, repo, ref, destDir string) error {
+	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return err
+	}
+
+	runGit := func(args ...string) error {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = destDir
+		cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git %s: %w\n%s", args[0], err, string(output))
+		}
+		return nil
+	}
+
+	// Initialize git repo (ignore error if already initialized)
+	runGit("init")
+
+	// Add remote (ignore error if already exists)
+	runGit("remote", "add", "origin", repoURL)
+
+	// Fetch the specified ref
+	if err := runGit("fetch", "--depth=1", "origin", ref); err != nil {
+		return err
+	}
+
+	// Checkout the fetched content
+	return runGit("checkout", "FETCH_HEAD")
+}
+
+// fileInfo implements fs.FileInfo.
+type fileInfo struct {
+	name    string
+	size    int64
+	mode    fs.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+func (f *fileInfo) Name() string       { return f.name }
+func (f *fileInfo) Size() int64        { return f.size }
+func (f *fileInfo) Mode() fs.FileMode  { return f.mode }
+func (f *fileInfo) ModTime() time.Time { return f.modTime }
+func (f *fileInfo) IsDir() bool        { return f.isDir }
+func (f *fileInfo) Sys() any           { return nil }

--- a/internal/vcs/repo.go
+++ b/internal/vcs/repo.go
@@ -1,0 +1,90 @@
+// Copyright 2024 The llar Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+// Repo represents a code hosting repository.
+// It provides version queries and can create filesystem views for specific refs.
+type Repo interface {
+	// Tags returns all tags from the repository.
+	Tags(ctx context.Context) ([]string, error)
+	// Latest returns the latest commit hash on the default branch.
+	Latest(ctx context.Context) (string, error)
+	// At returns a filesystem view of the repository at the specified ref.
+	// The returned fs.FS also implements fs.ReadFileFS and fs.ReadDirFS.
+	At(ref, localDir string) fs.FS
+	// Sync downloads the specified path to localDir.
+	Sync(ctx context.Context, ref, path, localDir string) error
+}
+
+// repo is the default implementation of Repo.
+type repo struct {
+	client client
+	host   string
+	owner  string
+	name   string
+}
+
+// NewRepo creates a new Repo for the given repository path.
+// repoPath format: "github.com/owner/repo"
+func NewRepo(repoPath string) (Repo, error) {
+	host, owner, repoName, err := parseRepoPath(repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := newClient(host)
+	if err != nil {
+		return nil, err
+	}
+
+	return &repo{
+		client: c,
+		host:   host,
+		owner:  owner,
+		name:   repoName,
+	}, nil
+}
+
+// Tags returns all tags from the repository.
+func (r *repo) Tags(ctx context.Context) ([]string, error) {
+	return r.client.Tags(ctx, r.owner, r.name)
+}
+
+// Latest returns the latest commit hash on the default branch.
+func (r *repo) Latest(ctx context.Context) (string, error) {
+	return r.client.Latest(ctx, r.owner, r.name)
+}
+
+// At returns a filesystem view of the repository at the specified ref.
+func (r *repo) At(ref, localDir string) fs.FS {
+	return &repoFS{
+		client:   r.client,
+		owner:    r.owner,
+		repoName: r.name,
+		ref:      ref,
+		localDir: localDir,
+	}
+}
+
+// Sync downloads the specified path to localDir.
+func (r *repo) Sync(ctx context.Context, ref, path, localDir string) error {
+	return r.client.SyncDir(ctx, r.owner, r.name, ref, path, localDir)
+}
+
+// parseRepoPath parses "github.com/owner/repo" into components.
+func parseRepoPath(repoPath string) (host, owner, repo string, err error) {
+	parts := strings.Split(repoPath, "/")
+	if len(parts) < 3 {
+		return "", "", "", fmt.Errorf("invalid repo path: %s, expected host/owner/repo", repoPath)
+	}
+	return parts[0], parts[1], strings.Join(parts[2:], "/"), nil
+}

--- a/internal/vcs/repo_test.go
+++ b/internal/vcs/repo_test.go
@@ -1,0 +1,588 @@
+// Copyright 2024 The llar Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRepoPath(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantHost  string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{"github.com/owner/repo", "github.com", "owner", "repo", false},
+		{"github.com/owner/repo/sub", "github.com", "owner", "repo/sub", false},
+		{"gitlab.com/org/project", "gitlab.com", "org", "project", false},
+		{"invalid", "", "", "", true},
+		{"only/two", "", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			host, owner, repo, err := parseRepoPath(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseRepoPath(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if host != tt.wantHost || owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Errorf("parseRepoPath(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tt.input, host, owner, repo, tt.wantHost, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestNewRepo(t *testing.T) {
+	// Test unsupported host
+	_, err := NewRepo("unsupported.com/owner/repo")
+	if err == nil {
+		t.Error("NewRepo with unsupported host should return error")
+	}
+
+	// Test valid GitHub repo
+	r, err := NewRepo("github.com/golang/go")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+	rr := r.(*repo)
+	if rr.host != "github.com" || rr.owner != "golang" || rr.name != "go" {
+		t.Errorf("NewRepo parsed incorrectly: got host=%q owner=%q name=%q",
+			rr.host, rr.owner, rr.name)
+	}
+}
+
+func TestRepoAt(t *testing.T) {
+	r, err := NewRepo("github.com/golang/go")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	fsys := r.At("v1.21.0", localDir)
+	rfs := fsys.(*repoFS)
+
+	if rfs.ref != "v1.21.0" {
+		t.Errorf("RepoFS.ref = %q, want %q", rfs.ref, "v1.21.0")
+	}
+	if rfs.localDir != localDir {
+		t.Errorf("RepoFS.localDir = %q, want %q", rfs.localDir, localDir)
+	}
+}
+
+// Integration tests (require network access)
+
+func TestRepoTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	ctx := context.Background()
+	tags, err := repo.Tags(ctx)
+	if err != nil {
+		t.Fatalf("Tags failed: %v", err)
+	}
+
+	if len(tags) == 0 {
+		t.Error("Tags returned empty list")
+	}
+}
+
+func TestRepoLatest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	ctx := context.Background()
+	latest, err := repo.Latest(ctx)
+	if err != nil {
+		t.Fatalf("Latest failed: %v", err)
+	}
+
+	if latest == "" {
+		t.Error("Latest returned empty string")
+	}
+	t.Logf("Latest commit: %s", latest)
+}
+
+func TestRepoFSReadFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	r, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	fsys := r.At("v68.0.0", localDir)
+	rfs := fsys.(fs.ReadFileFS)
+
+	// Read README.md
+	data, err := rfs.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("ReadFile returned empty data")
+	}
+
+	// Check file is cached locally
+	cached := filepath.Join(localDir, "README.md")
+	if _, err := os.Stat(cached); os.IsNotExist(err) {
+		t.Error("File was not cached locally")
+	}
+
+	// Second read should come from cache
+	data2, err := rfs.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("ReadFile (cached) failed: %v", err)
+	}
+
+	if string(data) != string(data2) {
+		t.Error("Cached data differs from original")
+	}
+}
+
+func TestRepoFSReadDir(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	r, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	fsys := r.At("v68.0.0", localDir)
+	rfs := fsys.(fs.ReadDirFS)
+
+	// Read root directory
+	entries, err := rfs.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Error("ReadDir returned empty list")
+	}
+
+	// Check some expected files/dirs exist
+	found := make(map[string]bool)
+	for _, e := range entries {
+		found[e.Name()] = true
+	}
+
+	if !found["README.md"] {
+		t.Error("README.md not found in directory listing")
+	}
+	if !found["github"] {
+		t.Error("github directory not found in directory listing")
+	}
+}
+
+func TestRepoSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	r, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	syncedDir := filepath.Join(localDir, ".github")
+
+	// Sync only the .github directory (smaller)
+	ctx := context.Background()
+	if err := r.Sync(ctx, "v68.0.0", ".github", syncedDir); err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Check directory was synced
+	if _, err := os.Stat(syncedDir); os.IsNotExist(err) {
+		t.Error(".github directory was not synced")
+	}
+
+	// Check some files exist in synced directory
+	entries, err := os.ReadDir(syncedDir)
+	if err != nil {
+		t.Fatalf("ReadDir synced dir failed: %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Error("Synced directory is empty")
+	}
+}
+
+func TestRepoFSOpen(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	repoFS := repo.At("v68.0.0", localDir)
+
+	// Open file (lazy loading)
+	f, err := repoFS.Open("README.md")
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	// File not downloaded yet (lazy)
+	cached := filepath.Join(localDir, "README.md")
+	if _, err := os.Stat(cached); !os.IsNotExist(err) {
+		t.Error("File should not be cached before Read")
+	}
+
+	// Read triggers download
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("Read returned empty data")
+	}
+
+	// Now file should be cached
+	if _, err := os.Stat(cached); os.IsNotExist(err) {
+		t.Error("File should be cached after Read")
+	}
+
+	// Stat should work
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+
+	if info.Name() != "README.md" {
+		t.Errorf("Stat Name = %q, want %q", info.Name(), "README.md")
+	}
+}
+
+func TestRepoFSOpenStatBeforeRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	repoFS := repo.At("v68.0.0", localDir)
+
+	f, err := repoFS.Open("README.md")
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	// Stat before Read should fetch from remote
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+
+	if info.Name() != "README.md" {
+		t.Errorf("Stat Name = %q, want %q", info.Name(), "README.md")
+	}
+
+	// File still not cached (Stat doesn't download content)
+	cached := filepath.Join(localDir, "README.md")
+	if _, err := os.Stat(cached); !os.IsNotExist(err) {
+		t.Error("File should not be cached after Stat only")
+	}
+}
+
+func TestRepoFSOpenMultipleReads(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	repoFS := repo.At("v68.0.0", localDir)
+
+	f, err := repoFS.Open("LICENSE")
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	// First read
+	buf1 := make([]byte, 10)
+	n1, err := f.Read(buf1)
+	if err != nil {
+		t.Fatalf("First Read failed: %v", err)
+	}
+
+	// Second read continues from where we left off
+	buf2 := make([]byte, 10)
+	n2, err := f.Read(buf2)
+	if err != nil {
+		t.Fatalf("Second Read failed: %v", err)
+	}
+
+	// Should read different content
+	if string(buf1[:n1]) == string(buf2[:n2]) && n1 == n2 {
+		t.Error("Multiple reads should advance position")
+	}
+}
+
+func TestRepoFSOpenNonExistent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	repoFS := repo.At("v68.0.0", localDir)
+
+	// Open succeeds (lazy)
+	f, err := repoFS.Open("nonexistent-file.txt")
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	// Read should fail for non-existent file
+	_, err = io.ReadAll(f)
+	if err == nil {
+		t.Error("Read should fail for non-existent file")
+	}
+}
+
+func TestRepoFSOpenFromCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	repo, err := NewRepo("github.com/google/go-github")
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	localDir := t.TempDir()
+	repoFS := repo.At("v68.0.0", localDir)
+
+	// Pre-populate cache
+	cached := filepath.Join(localDir, "cached.txt")
+	cachedContent := []byte("cached content")
+	if err := os.WriteFile(cached, cachedContent, 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	// Open should read from cache, not remote
+	f, err := repoFS.Open("cached.txt")
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if string(data) != string(cachedContent) {
+		t.Errorf("Read = %q, want %q (from cache)", string(data), string(cachedContent))
+	}
+}
+
+func TestGitHubClientSyncDirSparse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	client := newGitHubClient()
+	ctx := context.Background()
+	destDir := t.TempDir()
+
+	// Test sparse-checkout for a subdirectory
+	err := client.SyncDir(ctx, "google", "go-github", "v68.0.0", ".github", destDir)
+	if err != nil {
+		t.Fatalf("SyncDir sparse failed: %v", err)
+	}
+
+	// Check .git exists
+	gitDir := filepath.Join(destDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		t.Error(".git directory should exist")
+	}
+
+	// Read root directory entries (excluding .git)
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+
+	// Filter out .git directory
+	var nonGitEntries []os.DirEntry
+	for _, e := range entries {
+		if e.Name() != ".git" {
+			nonGitEntries = append(nonGitEntries, e)
+		}
+	}
+
+	// Sparse checkout should only have the target directory (.github)
+	if len(nonGitEntries) != 1 {
+		var names []string
+		for _, e := range nonGitEntries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("sparse-checkout should only contain target directory, got %d entries: %v", len(nonGitEntries), names)
+	}
+
+	if len(nonGitEntries) > 0 && nonGitEntries[0].Name() != ".github" {
+		t.Errorf("expected .github directory, got %s", nonGitEntries[0].Name())
+	}
+
+	// Check .github directory has content
+	githubDir := filepath.Join(destDir, ".github")
+	githubEntries, err := os.ReadDir(githubDir)
+	if err != nil {
+		t.Fatalf("ReadDir .github failed: %v", err)
+	}
+
+	if len(githubEntries) == 0 {
+		t.Error(".github directory should have content")
+	}
+
+	t.Logf("Sparse checkout: only .github with %d files", len(githubEntries))
+}
+
+func TestGitHubClientSyncDirShallowClone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	client := newGitHubClient()
+	ctx := context.Background()
+	destDir := t.TempDir()
+
+	// Test shallow clone for root directory (empty path)
+	err := client.SyncDir(ctx, "google", "go-github", "v68.0.0", "", destDir)
+	if err != nil {
+		t.Fatalf("SyncDir shallow clone failed: %v", err)
+	}
+
+	// Check README.md exists
+	readme := filepath.Join(destDir, "README.md")
+	if _, err := os.Stat(readme); os.IsNotExist(err) {
+		t.Error("README.md should exist")
+	}
+
+	// Check .git exists
+	gitDir := filepath.Join(destDir, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		t.Error(".git directory should exist")
+	}
+
+	// Check github directory exists (full repo)
+	githubDir := filepath.Join(destDir, "github")
+	if _, err := os.Stat(githubDir); os.IsNotExist(err) {
+		t.Error("github directory should exist in full clone")
+	}
+}
+
+func TestGitHubClientSyncDirSparseUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	client := newGitHubClient()
+	ctx := context.Background()
+	destDir := t.TempDir()
+
+	// First sync
+	err := client.SyncDir(ctx, "google", "go-github", "v68.0.0", ".github", destDir)
+	if err != nil {
+		t.Fatalf("First SyncDir failed: %v", err)
+	}
+
+	// Second sync should succeed (update scenario)
+	err = client.SyncDir(ctx, "google", "go-github", "v68.0.0", ".github", destDir)
+	if err != nil {
+		t.Fatalf("Second SyncDir (update) failed: %v", err)
+	}
+
+	// Verify content still exists
+	githubDir := filepath.Join(destDir, ".github")
+	entries, err := os.ReadDir(githubDir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Error(".github directory should have content after update")
+	}
+}
+
+func TestGitHubClientSyncDirShallowCloneUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	client := newGitHubClient()
+	ctx := context.Background()
+	destDir := t.TempDir()
+
+	// First sync
+	err := client.SyncDir(ctx, "google", "go-github", "v68.0.0", "", destDir)
+	if err != nil {
+		t.Fatalf("First SyncDir failed: %v", err)
+	}
+
+	// Second sync should succeed (update scenario)
+	err = client.SyncDir(ctx, "google", "go-github", "v68.0.0", "", destDir)
+	if err != nil {
+		t.Fatalf("Second SyncDir (update) failed: %v", err)
+	}
+
+	// Verify content still exists
+	readme := filepath.Join(destDir, "README.md")
+	if _, err := os.Stat(readme); os.IsNotExist(err) {
+		t.Error("README.md should exist after update")
+	}
+}

--- a/internal/vcs/repofs.go
+++ b/internal/vcs/repofs.go
@@ -1,0 +1,127 @@
+// Copyright 2024 The llar Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vcs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// repoFS implements fs.FS, fs.ReadFileFS, and fs.ReadDirFS.
+type repoFS struct {
+	client   client
+	owner    string
+	repoName string
+	ref      string
+	localDir string
+}
+
+// Open opens the named file for reading (lazy loading).
+func (r *repoFS) Open(name string) (fs.File, error) {
+	return &repoFile{
+		name:   name,
+		local:  filepath.Join(r.localDir, name),
+		client: r.client,
+		owner:  r.owner,
+		repo:   r.repoName,
+		ref:    r.ref,
+	}, nil
+}
+
+// ReadFile reads the content of a file.
+func (r *repoFS) ReadFile(name string) ([]byte, error) {
+	f, err := r.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
+// ReadDir reads the contents of a directory.
+func (r *repoFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	local := filepath.Join(r.localDir, name)
+
+	// Local directory exists and is not empty, read directly
+	if entries, err := os.ReadDir(local); err == nil && len(entries) > 0 {
+		return entries, nil
+	}
+
+	// Download the entire directory
+	ctx := context.Background()
+	if err := r.client.SyncDir(ctx, r.owner, r.repoName, r.ref, name, local); err != nil {
+		return nil, err
+	}
+
+	return os.ReadDir(local)
+}
+
+// repoFile implements fs.File with lazy loading.
+type repoFile struct {
+	name   string
+	local  string
+	client client
+	owner  string
+	repo   string
+	ref    string
+
+	once   sync.Once
+	reader *bytes.Reader
+	err    error
+}
+
+func (f *repoFile) load() {
+	// Try local first
+	if data, err := os.ReadFile(f.local); err == nil {
+		f.reader = bytes.NewReader(data)
+		return
+	}
+
+	// Fetch from remote
+	ctx := context.Background()
+	data, err := f.client.ReadFile(ctx, f.owner, f.repo, f.ref, f.name)
+	if err != nil {
+		f.err = err
+		return
+	}
+
+	// Save to local
+	if err := os.MkdirAll(filepath.Dir(f.local), 0755); err != nil {
+		f.err = err
+		return
+	}
+	if err := os.WriteFile(f.local, data, 0644); err != nil {
+		f.err = err
+		return
+	}
+
+	f.reader = bytes.NewReader(data)
+}
+
+func (f *repoFile) Read(p []byte) (int, error) {
+	f.once.Do(f.load)
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.reader.Read(p)
+}
+
+func (f *repoFile) Stat() (fs.FileInfo, error) {
+	// Try local first
+	if info, err := os.Stat(f.local); err == nil {
+		return info, nil
+	}
+
+	// Fetch from remote
+	ctx := context.Background()
+	return f.client.Stat(ctx, f.owner, f.repo, f.ref, f.name)
+}
+
+func (f *repoFile) Close() error { return nil }


### PR DESCRIPTION
Implement a new VCS package that provides an abstraction layer for interacting with code hosting platforms:

- Add client interface defining methods for repository operations (Tags, Latest, Stat, ReadFile, SyncDir)
- Implement GitHub client using raw URLs and git commands (no API dependencies)
- Add Repo and RepoFS types for repository and filesystem access with local caching
- Include lazyFile implementation for on-demand file downloads
- Add comprehensive test coverage for GitHub client and repository operations

The implementation uses git ls-remote for metadata and raw.githubusercontent.com for file access, avoiding GitHub API rate limits. All downloaded content is cached locally in a configurable directory.