### PR TITLE
ci: update Go version matrix to 1.24.x and 1.25.x

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,9 +3,14 @@ on:
   push:
     branches:
       - "**"
+      - "!dependabot/**"
+      - "!xgopilot/**"
   pull_request:
-    branches:
-      - "**"
+    branches: [ "**" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Drop support for Go 1.22.x and 1.23.x, add Go 1.25.x to keep the CI testing current with recent Go releases.