### PR TITLE
docs: remove logo image from README temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img width="250" height="250" alt="f55906e5-298e-44c5-ac10-59f74ba15051" src="https://github.com/user-attachments/assets/38f48dc3-6676-420e-9745-c258ff8d487c" />
-</p>
-
 # LLAR
 
 LLAR, a cloud-based package management service


### PR DESCRIPTION
The logo size may be incorrect, however, it's hard to re-upload to GitHub.

So remove it temporarily, when MVP get merged, we will upload the correct image.