### PR TITLE
feat(buildsys): add autotools and cmake build system helpers

### DIFF
--- a/pkgs/buildsys/autotools/autotools.go
+++ b/pkgs/buildsys/autotools/autotools.go
@@ -1,0 +1,233 @@
+package autotools
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/goplus/llar/formula"
+	"github.com/goplus/llar/pkgs/buildsys"
+	"github.com/goplus/llar/pkgs/mod/module"
+)
+
+// AutoTools wraps common Autotools build steps with chainable configuration.
+type AutoTools struct {
+	ctx        *formula.Context
+	SourceDir  string
+	buildDir   string
+	installDir string
+	env        map[string]string
+}
+
+var _ buildsys.BuildSystem = (*AutoTools)(nil)
+
+// New creates a new AutoTools helper. Optional context enables use(mod).
+func New(ctx *formula.Context) *AutoTools {
+	sourceDir := ""
+	if ctx != nil {
+		sourceDir = ctx.SourceDir
+	}
+	buildDir, err := os.MkdirTemp("", "llar-build-")
+	if err != nil {
+		buildDir = filepath.Join(sourceDir, "build")
+	}
+	a := &AutoTools{
+		SourceDir:  sourceDir,
+		buildDir:   buildDir,
+		installDir: filepath.Join(sourceDir, "build"),
+		env:        map[string]string{},
+	}
+	a.ctx = ctx
+	return a
+}
+
+func (a *AutoTools) Source(dir string) {
+	a.SourceDir = dir
+}
+
+func (a *AutoTools) InstallDir(dir string) {
+	a.installDir = dir
+}
+
+func (a *AutoTools) Env(key, value string) {
+	if a.env == nil {
+		a.env = map[string]string{}
+	}
+	a.env[key] = value
+	_ = os.Setenv(key, value)
+}
+
+// Use configures the build environment to use the specified module.
+func (a *AutoTools) Use(mod module.Version) {
+	if a.ctx == nil || a.ctx.BuildResults == nil {
+		panic("autotools: context is not set")
+	}
+	depResult, ok := a.ctx.BuildResults[mod]
+	if !ok {
+		panic(fmt.Sprintf("autotools: dep not found: %s@%s", mod.Path, mod.Version))
+	}
+	buildDir := depResult.Dir
+
+	includeDir := filepath.Join(buildDir, "include")
+	libDir := filepath.Join(buildDir, "lib")
+	pkgconfigDir := filepath.Join(buildDir, "lib", "pkgconfig")
+
+	// PKG_CONFIG_PATH - pkg-config path (all platforms)
+	if _, err := os.Stat(pkgconfigDir); err == nil {
+		prependEnv("PKG_CONFIG_PATH", pkgconfigDir)
+	}
+
+	// CMAKE paths (all platforms)
+	if _, err := os.Stat(buildDir); err == nil {
+		prependEnv("CMAKE_PREFIX_PATH", buildDir)
+	}
+	if _, err := os.Stat(includeDir); err == nil {
+		prependEnv("CMAKE_INCLUDE_PATH", includeDir)
+	}
+	if _, err := os.Stat(libDir); err == nil {
+		prependEnv("CMAKE_LIBRARY_PATH", libDir)
+	}
+
+	// Platform-specific settings
+	if runtime.GOOS == "windows" {
+		// Windows MSVC environment variables
+		if _, err := os.Stat(includeDir); err == nil {
+			prependEnv("INCLUDE", includeDir)
+		}
+		if _, err := os.Stat(libDir); err == nil {
+			prependEnv("LIB", libDir)
+		}
+	} else {
+		// Unix (Linux/macOS) - Autotools/GCC style flags
+		if _, err := os.Stat(includeDir); err == nil {
+			appendFlag("CPPFLAGS", "-I"+includeDir)
+		}
+		if _, err := os.Stat(libDir); err == nil {
+			appendFlag("LDFLAGS", "-L"+libDir)
+		}
+	}
+
+}
+
+// Configure runs ./configure with standard flags.
+func (a *AutoTools) Configure(args ...string) error {
+	buildDir := a.buildDir
+	if buildDir == "" {
+		buildDir = "."
+	}
+	if err := os.MkdirAll(buildDir, 0755); err != nil {
+		return err
+	}
+
+	exe := "./configure"
+	if buildDir != "." && buildDir != "" {
+		exe = filepath.Join(a.SourceDir, "configure")
+	}
+
+	configArgs := []string{}
+	if a.installDir != "" {
+		configArgs = append(configArgs, "--prefix="+a.installDir)
+	}
+	configArgs = append(configArgs, args...)
+
+	return run(exe, configArgs, a.env, buildDir)
+}
+
+// Build runs make (or provided args) in the build directory.
+func (a *AutoTools) Build(args ...string) error {
+	buildDir := a.buildDir
+	if buildDir == "" {
+		buildDir = "."
+	}
+	cmdArgs := []string{}
+	if len(args) == 0 {
+		cmdArgs = append(cmdArgs, "make")
+	} else {
+		cmdArgs = append(cmdArgs, args...)
+	}
+	return run(cmdArgs[0], cmdArgs[1:], a.env, buildDir)
+}
+
+// Install runs make install (or provided args) in the build directory.
+func (a *AutoTools) Install(args ...string) error {
+	buildDir := a.buildDir
+	if buildDir == "" {
+		buildDir = "."
+	}
+	cmdArgs := []string{"make", "install"}
+	if len(args) > 0 {
+		cmdArgs = args
+	}
+	return run(cmdArgs[0], cmdArgs[1:], a.env, buildDir)
+}
+
+// OutputDir returns the install dir if set, otherwise the build dir.
+func (a *AutoTools) OutputDir() string {
+	if a.installDir != "" {
+		return a.installDir
+	}
+	return a.buildDir
+}
+
+func run(bin string, args []string, env map[string]string, workdir string) error {
+	cmd := exec.Command(bin, args...)
+	if workdir != "" {
+		cmd.Dir = workdir
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if len(env) > 0 {
+		cmd.Env = mergeEnv(os.Environ(), env)
+	}
+	return cmd.Run()
+}
+
+func mergeEnv(base []string, override map[string]string) []string {
+	envMap := make(map[string]string, len(base))
+	for _, kv := range base {
+		if k, v, ok := strings.Cut(kv, "="); ok {
+			envMap[k] = v
+		}
+	}
+	for k, v := range override {
+		envMap[k] = v
+	}
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, k+"="+envMap[k])
+	}
+	return out
+}
+
+// prependEnv prepends a value to an environment variable using the appropriate separator.
+func prependEnv(key, value string) {
+	sep := ":"
+	if runtime.GOOS == "windows" {
+		sep = ";"
+	}
+	current := os.Getenv(key)
+	if current == "" {
+		os.Setenv(key, value)
+	} else {
+		os.Setenv(key, value+sep+current)
+	}
+}
+
+// appendFlag appends a flag to an environment variable (space-separated).
+func appendFlag(key, flag string) {
+	current := os.Getenv(key)
+	if current == "" {
+		os.Setenv(key, flag)
+	} else {
+		os.Setenv(key, strings.TrimSpace(current+" "+flag))
+	}
+}

--- a/pkgs/buildsys/autotools/autotools_test.go
+++ b/pkgs/buildsys/autotools/autotools_test.go
@@ -1,0 +1,148 @@
+package autotools
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llar/formula"
+	"github.com/goplus/llar/pkgs/mod/module"
+)
+
+func TestUseSetsEnv(t *testing.T) {
+	tempDir := t.TempDir()
+	includeDir := filepath.Join(tempDir, "include")
+	libDir := filepath.Join(tempDir, "lib")
+	pkgconfigDir := filepath.Join(libDir, "pkgconfig")
+
+	for _, dir := range []string{includeDir, libDir, pkgconfigDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	for _, key := range []string{
+		"PKG_CONFIG_PATH",
+		"CMAKE_PREFIX_PATH",
+		"CMAKE_INCLUDE_PATH",
+		"CMAKE_LIBRARY_PATH",
+		"INCLUDE",
+		"LIB",
+		"CPPFLAGS",
+		"LDFLAGS",
+	} {
+		t.Setenv(key, "")
+	}
+
+	ctx := &formula.Context{
+		BuildResults: map[module.Version]formula.BuildResult{
+			{Path: "dep", Version: "1.0.0"}: {Dir: tempDir},
+		},
+	}
+	a := New(ctx)
+
+	a.Use(module.Version{Path: "dep", Version: "1.0.0"})
+
+	expectEq := map[string]string{
+		"PKG_CONFIG_PATH":    pkgconfigDir,
+		"CMAKE_PREFIX_PATH":  tempDir,
+		"CMAKE_INCLUDE_PATH": includeDir,
+		"CMAKE_LIBRARY_PATH": libDir,
+	}
+	for k, v := range expectEq {
+		if got := os.Getenv(k); got != v {
+			t.Fatalf("%s = %q, want %q", k, got, v)
+		}
+	}
+
+	if runtime.GOOS == "windows" {
+		if got := os.Getenv("INCLUDE"); got != includeDir {
+			t.Fatalf("INCLUDE = %q, want %q", got, includeDir)
+		}
+		if got := os.Getenv("LIB"); got != libDir {
+			t.Fatalf("LIB = %q, want %q", got, libDir)
+		}
+	} else {
+		if got := os.Getenv("CPPFLAGS"); strings.TrimSpace(got) != "-I"+includeDir {
+			t.Fatalf("CPPFLAGS = %q, want %q", got, "-I"+includeDir)
+		}
+		if got := os.Getenv("LDFLAGS"); strings.TrimSpace(got) != "-L"+libDir {
+			t.Fatalf("LDFLAGS = %q, want %q", got, "-L"+libDir)
+		}
+	}
+}
+
+func TestOutputDirPrefersInstall(t *testing.T) {
+	a := New(nil)
+	if got := a.OutputDir(); got != "build" {
+		t.Fatalf("default OutputDir = %q, want %q", got, "build")
+	}
+	a.InstallDir("custom-install")
+	if got := a.OutputDir(); got != "custom-install" {
+		t.Fatalf("OutputDir after InstallDir = %q, want %q", got, "custom-install")
+	}
+}
+
+func TestConfigureBuildInstallE2E(t *testing.T) {
+	for _, bin := range []string{"make", "cc", "ar"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not found in PATH", bin)
+		}
+	}
+
+	tmp := t.TempDir()
+	installDir := filepath.Join(tmp, "install")
+	sourceDir := filepath.Join("testdata", "project")
+	absSourceDir, err := filepath.Abs(sourceDir)
+	if err != nil {
+		t.Fatalf("abs source dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(absSourceDir, "configure")); err != nil {
+		t.Fatalf("missing configure: %v", err)
+	}
+
+	t.Setenv("CUSTOM", "")
+
+	a := New(nil)
+	defer os.RemoveAll(a.buildDir)
+	a.Env("CUSTOM", "VAL")
+	a.Source(absSourceDir)
+	a.InstallDir(installDir)
+
+	if err := a.Configure("--enable-foo"); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	if err := a.Build(); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := a.Install(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cache := filepath.Join(a.buildDir, "config.log")
+	data, err := os.ReadFile(cache)
+	if err != nil {
+		t.Fatalf("read config.log: %v", err)
+	}
+	content := string(data)
+	for _, snippet := range []string{
+		"CUSTOM=VAL",
+		"PREFIX=" + installDir,
+	} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("config.log missing %q", snippet)
+		}
+	}
+
+	wantLib := filepath.Join(installDir, "lib", "libdummy.a")
+	if _, err := os.Stat(wantLib); err != nil {
+		t.Fatalf("installed lib missing: %v", err)
+	}
+	wantHeader := filepath.Join(installDir, "include", "dummy.h")
+	if _, err := os.Stat(wantHeader); err != nil {
+		t.Fatalf("installed header missing: %v", err)
+	}
+}

--- a/pkgs/buildsys/autotools/testdata/project/Makefile.in
+++ b/pkgs/buildsys/autotools/testdata/project/Makefile.in
@@ -1,0 +1,26 @@
+prefix = @prefix@
+srcdir = @srcdir@
+
+CC ?= cc
+AR ?= ar
+CFLAGS ?= -O2
+
+LIB = libdummy.a
+OBJ = dummy.o
+
+all: $(LIB)
+
+dummy.o: $(srcdir)/dummy.c $(srcdir)/dummy.h
+	$(CC) $(CFLAGS) -c $(srcdir)/dummy.c -o $@
+
+$(LIB): $(OBJ)
+	$(AR) rcs $@ $(OBJ)
+
+install: $(LIB)
+	dest="$${DESTDIR:+$${DESTDIR}/}$(prefix)"; \
+	mkdir -p "$$dest/lib" "$$dest/include"; \
+	cp $(LIB) "$$dest/lib/"; \
+	cp $(srcdir)/dummy.h "$$dest/include/"
+
+clean:
+	rm -f $(OBJ) $(LIB)

--- a/pkgs/buildsys/autotools/testdata/project/configure
+++ b/pkgs/buildsys/autotools/testdata/project/configure
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+prefix="/usr/local"
+srcdir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--prefix=*)
+			prefix="${1#*=}"
+			;;
+		--prefix)
+			shift
+			prefix="$1"
+			;;
+	esac
+	shift || true
+done
+
+sed \
+	-e "s|@prefix@|$prefix|g" \
+	-e "s|@srcdir@|$srcdir|g" \
+	"$srcdir/Makefile.in" > Makefile
+
+echo "CUSTOM=${CUSTOM}" > config.log
+echo "PREFIX=${prefix}" >> config.log

--- a/pkgs/buildsys/autotools/testdata/project/dummy.c
+++ b/pkgs/buildsys/autotools/testdata/project/dummy.c
@@ -1,0 +1,5 @@
+#include "dummy.h"
+
+int dummy_add(int a, int b) {
+	return a + b;
+}

--- a/pkgs/buildsys/autotools/testdata/project/dummy.h
+++ b/pkgs/buildsys/autotools/testdata/project/dummy.h
@@ -1,0 +1,6 @@
+#ifndef DUMMY_H
+#define DUMMY_H
+
+int dummy_add(int a, int b);
+
+#endif

--- a/pkgs/buildsys/buildsys.go
+++ b/pkgs/buildsys/buildsys.go
@@ -1,0 +1,25 @@
+package buildsys
+
+import "github.com/goplus/llar/pkgs/mod/module"
+
+// BuildSystem captures shared capabilities of build helpers (CMake, Autotools, etc).
+// It keeps the common lifecycle and dependency/env setup; implementations add their own extras.
+type BuildSystem interface {
+	// Use injects a built dependency into the environment.
+	Use(mod module.Version)
+
+	// Basic paths.
+	Source(dir string)
+	InstallDir(dir string)
+
+	// Environment helper.
+	Env(key, val string)
+
+	// Lifecycle.
+	Configure(args ...string) error
+	Build(args ...string) error
+	Install(args ...string) error
+
+	// Where artifacts land.
+	OutputDir() string
+}

--- a/pkgs/buildsys/cmake/cmake.go
+++ b/pkgs/buildsys/cmake/cmake.go
@@ -1,0 +1,297 @@
+package cmake
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/goplus/llar/formula"
+	"github.com/goplus/llar/pkgs/buildsys"
+	"github.com/goplus/llar/pkgs/mod/module"
+)
+
+// CMake wraps common CMake build steps with chainable configuration.
+type defineValue struct {
+	value    string
+	typeName string
+}
+
+type CMake struct {
+	ctx        *formula.Context
+	SourceDir  string
+	buildDir   string
+	installDir string
+	generator  string
+	buildType  string
+	toolchain  string
+	Defines    map[string]defineValue
+	env        map[string]string
+}
+
+var _ buildsys.BuildSystem = (*CMake)(nil)
+
+// New creates a new CMake helper. Optional context enables use(mod).
+func New(ctx *formula.Context) *CMake {
+	sourceDir := ""
+	if ctx != nil {
+		sourceDir = ctx.SourceDir
+	}
+	buildDir, err := os.MkdirTemp("", "llar-build-")
+	if err != nil {
+		buildDir = filepath.Join(sourceDir, "build")
+	}
+	c := &CMake{
+		SourceDir:  sourceDir,
+		buildDir:   buildDir,
+		installDir: filepath.Join(sourceDir, "build"),
+		Defines:    map[string]defineValue{},
+		env:        map[string]string{},
+	}
+	c.ctx = ctx
+	return c
+}
+
+func (c *CMake) Source(dir string) {
+	c.SourceDir = dir
+}
+
+func (c *CMake) InstallDir(dir string) {
+	c.installDir = dir
+}
+
+func (c *CMake) Generator(name string) *CMake {
+	c.generator = name
+	return c
+}
+
+func (c *CMake) BuildType(name string) *CMake {
+	c.buildType = name
+	return c
+}
+
+func (c *CMake) Toolchain(path string) *CMake {
+	c.toolchain = path
+	return c
+}
+
+func (c *CMake) Define(key, value string) *CMake {
+	if c.Defines == nil {
+		c.Defines = map[string]defineValue{}
+	}
+	c.Defines[key] = defineValue{value: value, typeName: "STRING"}
+	return c
+}
+
+func (c *CMake) DefineBool(key string, value bool) *CMake {
+	if c.Defines == nil {
+		c.Defines = map[string]defineValue{}
+	}
+	if value {
+		c.Defines[key] = defineValue{value: "ON", typeName: "BOOL"}
+		return c
+	}
+	c.Defines[key] = defineValue{value: "OFF", typeName: "BOOL"}
+	return c
+}
+
+func (c *CMake) Env(key, value string) {
+	if c.env == nil {
+		c.env = map[string]string{}
+	}
+	c.env[key] = value
+	_ = os.Setenv(key, value)
+}
+
+// Use configures the build environment to use the specified module.
+func (c *CMake) Use(mod module.Version) {
+	if c.ctx == nil || c.ctx.BuildResults == nil {
+		panic("cmake: context is not set")
+	}
+	depResult, ok := c.ctx.BuildResults[mod]
+	if !ok {
+		panic(fmt.Sprintf("cmake: dep not found: %s@%s", mod.Path, mod.Version))
+	}
+	buildDir := depResult.Dir
+
+	includeDir := filepath.Join(buildDir, "include")
+	libDir := filepath.Join(buildDir, "lib")
+	pkgconfigDir := filepath.Join(buildDir, "lib", "pkgconfig")
+
+	// PKG_CONFIG_PATH - pkg-config path (all platforms)
+	if _, err := os.Stat(pkgconfigDir); err == nil {
+		prependEnv("PKG_CONFIG_PATH", pkgconfigDir)
+	}
+
+	// CMAKE paths (all platforms)
+	if _, err := os.Stat(buildDir); err == nil {
+		prependEnv("CMAKE_PREFIX_PATH", buildDir)
+	}
+	if _, err := os.Stat(includeDir); err == nil {
+		prependEnv("CMAKE_INCLUDE_PATH", includeDir)
+	}
+	if _, err := os.Stat(libDir); err == nil {
+		prependEnv("CMAKE_LIBRARY_PATH", libDir)
+	}
+
+	// Platform-specific settings
+	if runtime.GOOS == "windows" {
+		// Windows MSVC environment variables
+		if _, err := os.Stat(includeDir); err == nil {
+			prependEnv("INCLUDE", includeDir)
+		}
+		if _, err := os.Stat(libDir); err == nil {
+			prependEnv("LIB", libDir)
+		}
+	} else {
+		// Unix (Linux/macOS) - Autotools/GCC style flags
+		if _, err := os.Stat(includeDir); err == nil {
+			appendFlag("CPPFLAGS", "-I"+includeDir)
+		}
+		if _, err := os.Stat(libDir); err == nil {
+			appendFlag("LDFLAGS", "-L"+libDir)
+		}
+	}
+
+}
+
+func (c *CMake) Configure(args ...string) error {
+	buildDir := c.buildDir
+	if buildDir == "" {
+		buildDir = "build"
+	}
+	if err := os.MkdirAll(buildDir, 0755); err != nil {
+		return err
+	}
+	cmakeArgs := []string{"-S", c.SourceDir, "-B", buildDir}
+	if c.generator != "" {
+		cmakeArgs = append(cmakeArgs, "-G", c.generator)
+	}
+	if c.installDir != "" {
+		c.Define("CMAKE_INSTALL_PREFIX", c.installDir)
+	}
+	if c.toolchain != "" {
+		c.Define("CMAKE_TOOLCHAIN_FILE", c.toolchain)
+	}
+	if c.buildType != "" {
+		c.Define("CMAKE_BUILD_TYPE", c.buildType)
+	}
+	cmakeArgs = append(cmakeArgs, c.definesArgs()...)
+	cmakeArgs = append(cmakeArgs, args...)
+
+	return run("cmake", cmakeArgs, c.env)
+}
+
+func (c *CMake) Build(args ...string) error {
+	buildDir := c.buildDir
+	if buildDir == "" {
+		buildDir = "build"
+	}
+	cmdArgs := []string{"--build", buildDir}
+	if c.buildType != "" {
+		cmdArgs = append(cmdArgs, "--config", c.buildType)
+	}
+	cmdArgs = append(cmdArgs, args...)
+	return run("cmake", cmdArgs, c.env)
+}
+
+func (c *CMake) Install(args ...string) error {
+	buildDir := c.buildDir
+	if buildDir == "" {
+		buildDir = "build"
+	}
+	cmdArgs := []string{"--install", buildDir}
+	if c.installDir != "" {
+		cmdArgs = append(cmdArgs, "--prefix", c.installDir)
+	}
+	cmdArgs = append(cmdArgs, args...)
+	return run("cmake", cmdArgs, c.env)
+}
+
+// OutputDir returns the install dir if set, otherwise the build dir.
+func (c *CMake) OutputDir() string {
+	if c.installDir != "" {
+		return c.installDir
+	}
+	return c.buildDir
+}
+
+func (c *CMake) definesArgs() []string {
+	if len(c.Defines) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(c.Defines))
+	for k := range c.Defines {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	args := make([]string, 0, len(keys))
+	for _, k := range keys {
+		def := c.Defines[k]
+		if def.typeName != "" {
+			args = append(args, "-D"+k+":"+def.typeName+"="+def.value)
+			continue
+		}
+		args = append(args, "-D"+k+"="+def.value)
+	}
+	return args
+}
+
+func run(bin string, args []string, env map[string]string) error {
+	cmd := exec.Command(bin, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if len(env) > 0 {
+		cmd.Env = mergeEnv(os.Environ(), env)
+	}
+	return cmd.Run()
+}
+
+func mergeEnv(base []string, override map[string]string) []string {
+	envMap := make(map[string]string, len(base))
+	for _, kv := range base {
+		if k, v, ok := strings.Cut(kv, "="); ok {
+			envMap[k] = v
+		}
+	}
+	for k, v := range override {
+		envMap[k] = v
+	}
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, k+"="+envMap[k])
+	}
+	return out
+}
+
+// prependEnv prepends a value to an environment variable using the appropriate separator.
+func prependEnv(key, value string) {
+	sep := ":"
+	if runtime.GOOS == "windows" {
+		sep = ";"
+	}
+	current := os.Getenv(key)
+	if current == "" {
+		os.Setenv(key, value)
+	} else {
+		os.Setenv(key, value+sep+current)
+	}
+}
+
+// appendFlag appends a flag to an environment variable (space-separated).
+func appendFlag(key, flag string) {
+	current := os.Getenv(key)
+	if current == "" {
+		os.Setenv(key, flag)
+	} else {
+		os.Setenv(key, strings.TrimSpace(current+" "+flag))
+	}
+}

--- a/pkgs/buildsys/cmake/cmake_test.go
+++ b/pkgs/buildsys/cmake/cmake_test.go
@@ -1,0 +1,151 @@
+package cmake
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llar/formula"
+	"github.com/goplus/llar/pkgs/mod/module"
+)
+
+func TestUseSetsEnv(t *testing.T) {
+	tempDir := t.TempDir()
+	includeDir := filepath.Join(tempDir, "include")
+	libDir := filepath.Join(tempDir, "lib")
+	pkgconfigDir := filepath.Join(libDir, "pkgconfig")
+
+	for _, dir := range []string{includeDir, libDir, pkgconfigDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	for _, key := range []string{
+		"PKG_CONFIG_PATH",
+		"CMAKE_PREFIX_PATH",
+		"CMAKE_INCLUDE_PATH",
+		"CMAKE_LIBRARY_PATH",
+		"INCLUDE",
+		"LIB",
+		"CPPFLAGS",
+		"LDFLAGS",
+	} {
+		t.Setenv(key, "")
+	}
+
+	ctx := &formula.Context{
+		BuildResults: map[module.Version]formula.BuildResult{
+			{Path: "dep", Version: "1.0.0"}: {Dir: tempDir},
+		},
+	}
+	c := New(ctx)
+
+	c.Use(module.Version{Path: "dep", Version: "1.0.0"})
+
+	expectEq := map[string]string{
+		"PKG_CONFIG_PATH":    pkgconfigDir,
+		"CMAKE_PREFIX_PATH":  tempDir,
+		"CMAKE_INCLUDE_PATH": includeDir,
+		"CMAKE_LIBRARY_PATH": libDir,
+	}
+	for k, v := range expectEq {
+		if got := os.Getenv(k); got != v {
+			t.Fatalf("%s = %q, want %q", k, got, v)
+		}
+	}
+
+	if runtime.GOOS == "windows" {
+		if got := os.Getenv("INCLUDE"); got != includeDir {
+			t.Fatalf("INCLUDE = %q, want %q", got, includeDir)
+		}
+		if got := os.Getenv("LIB"); got != libDir {
+			t.Fatalf("LIB = %q, want %q", got, libDir)
+		}
+	} else {
+		if got := os.Getenv("CPPFLAGS"); strings.TrimSpace(got) != "-I"+includeDir {
+			t.Fatalf("CPPFLAGS = %q, want %q", got, "-I"+includeDir)
+		}
+		if got := os.Getenv("LDFLAGS"); strings.TrimSpace(got) != "-L"+libDir {
+			t.Fatalf("LDFLAGS = %q, want %q", got, "-L"+libDir)
+		}
+	}
+}
+
+func TestOutputDirPrefersInstall(t *testing.T) {
+	c := New(nil)
+	if got := c.OutputDir(); got != "build" {
+		t.Fatalf("default OutputDir = %q, want %q", got, "build")
+	}
+	c.InstallDir("custom-install")
+	if got := c.OutputDir(); got != "custom-install" {
+		t.Fatalf("OutputDir after InstallDir = %q, want %q", got, "custom-install")
+	}
+}
+
+func TestConfigureBuildInstallE2E(t *testing.T) {
+	if _, err := exec.LookPath("cmake"); err != nil {
+		t.Skip("cmake not found in PATH")
+	}
+
+	tmp := t.TempDir()
+	installDir := filepath.Join(tmp, "install")
+	sourceDir := filepath.Join("testdata", "project")
+
+	c := New(nil)
+	defer os.RemoveAll(c.buildDir)
+	c.Env("CUSTOM", "VAL")
+	c.Source(sourceDir)
+	c.InstallDir(installDir)
+	c.BuildType("Release")
+	c.Generator("Unix Makefiles")
+	toolchain := filepath.Join(tmp, "toolchain.cmake")
+	if err := os.WriteFile(toolchain, []byte("# dummy toolchain"), 0o644); err != nil {
+		t.Fatalf("write toolchain: %v", err)
+	}
+	c.Toolchain(toolchain)
+	c.Define("FOO", "BAR")
+	c.DefineBool("ENABLE", true)
+	c.DefineBool("DISABLE", false)
+
+	if err := c.Configure(); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	if err := c.Build("--config", "Release"); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if err := c.Install(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Verify install outputs.
+	wantLib := filepath.Join(installDir, "lib", "libdummy.a")
+	if _, err := os.Stat(wantLib); err != nil {
+		t.Fatalf("installed lib missing: %v", err)
+	}
+	wantHeader := filepath.Join(installDir, "include", "dummy.h")
+	if _, err := os.Stat(wantHeader); err != nil {
+		t.Fatalf("installed header missing: %v", err)
+	}
+
+	// Verify cache contains our definitions.
+	cache := filepath.Join(c.buildDir, "CMakeCache.txt")
+	data, err := os.ReadFile(cache)
+	if err != nil {
+		t.Fatalf("read cache: %v", err)
+	}
+	content := string(data)
+	for _, snippet := range []string{
+		"FOO:STRING=BAR",
+		"ENABLE:BOOL=ON",
+		"DISABLE:BOOL=OFF",
+		"CMAKE_BUILD_TYPE:STRING=Release",
+	} {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("cache missing %q", snippet)
+		}
+	}
+}

--- a/pkgs/buildsys/cmake/testdata/project/CMakeLists.txt
+++ b/pkgs/buildsys/cmake/testdata/project/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(dummy C)
+
+add_library(dummy STATIC dummy.c)
+target_include_directories(dummy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+install(TARGETS dummy ARCHIVE DESTINATION lib)
+install(DIRECTORY include/ DESTINATION include)

--- a/pkgs/buildsys/cmake/testdata/project/dummy.c
+++ b/pkgs/buildsys/cmake/testdata/project/dummy.c
@@ -1,0 +1,3 @@
+int dummy_add(int a, int b) {
+    return a + b;
+}

--- a/pkgs/buildsys/cmake/testdata/project/include/dummy.h
+++ b/pkgs/buildsys/cmake/testdata/project/include/dummy.h
@@ -1,0 +1,2 @@
+#pragma once
+int dummy_add(int a, int b);


### PR DESCRIPTION
Add comprehensive build system abstractions for Autotools and CMake to simplify C/C++ package compilation and dependency management.

Changes:
- Implement AutoTools helper with configure/make/install workflow
- Implement CMake helper with generator selection and define management
- Support chainable configuration methods for build directories and env vars
- Add Use() method to integrate module dependencies via build context
- Handle platform-specific environment variables (Unix CPPFLAGS/LDFLAGS, Windows INCLUDE/LIB)
- Auto-configure PKG_CONFIG_PATH and CMAKE_PREFIX_PATH for dependencies

Both helpers implement the BuildSystem interface and provide a fluent API for formula authors to declaratively configure native builds.