### PR TITLE
feat(upload): pass configured GHCR username

### DIFF
--- a/internal/upload/ghcr.go
+++ b/internal/upload/ghcr.go
@@ -20,8 +20,9 @@ import (
 )
 
 type GHCRConfig struct {
-	Owner string
-	Token string
+	Owner    string
+	Username string
+	Token    string
 }
 
 func NewGHCR(cfg GHCRConfig) Uploader {
@@ -37,6 +38,10 @@ type ghcrUploader struct {
 }
 
 type indexWriter func(ctx context.Context, ref string, index v1.ImageIndex, username, token string) error
+
+func (u ghcrUploader) Type() string {
+	return "ghcr"
+}
 
 func (u ghcrUploader) Upload(ctx context.Context, r io.ReadSeeker, opts Options) (Result, error) {
 	ref, err := parseGHCRName(opts.Name, u.cfg.Owner)
@@ -72,7 +77,7 @@ func (u ghcrUploader) Upload(ctx context.Context, r io.ReadSeeker, opts Options)
 	if writeIndex == nil {
 		writeIndex = writeRemoteIndex
 	}
-	if err := writeIndex(ctx, ref.String(), index, u.cfg.Owner, u.cfg.Token); err != nil {
+	if err := writeIndex(ctx, ref.String(), index, u.cfg.Username, u.cfg.Token); err != nil {
 		return Result{}, err
 	}
 
@@ -191,11 +196,8 @@ func writeRemoteIndex(ctx context.Context, ref string, index v1.ImageIndex, user
 	}
 	opts := []remote.Option{remote.WithContext(ctx)}
 	if token != "" {
-		if username == "" {
-			username = "llar"
-		}
 		opts = append(opts, remote.WithAuth(authn.FromConfig(authn.AuthConfig{
-			Username: strings.ToLower(username),
+			Username: username,
 			Password: token,
 		})))
 	}

--- a/internal/upload/ghcr_integration_test.go
+++ b/internal/upload/ghcr_integration_test.go
@@ -25,8 +25,15 @@ func TestGHCRUploadIntegrationMeteorsLiuLlar(t *testing.T) {
 	if token == "" {
 		t.Skip("set GHCR_TOKEN, GITHUB_TOKEN, or CR_PAT to run live GHCR upload")
 	}
+	username := os.Getenv("GHCR_USERNAME")
+	if username == "" {
+		username = os.Getenv("GITHUB_ACTOR")
+	}
+	if username == "" {
+		t.Skip("set GHCR_USERNAME or GITHUB_ACTOR to run live GHCR upload")
+	}
 
-	uploader := NewGHCR(GHCRConfig{Owner: "MeteorsLiu", Token: token})
+	uploader := NewGHCR(GHCRConfig{Owner: "MeteorsLiu", Username: username, Token: token})
 	artifactPath := buildZlibArtifact(t)
 	artifact, err := os.Open(artifactPath)
 	if err != nil {

--- a/internal/upload/ghcr_test.go
+++ b/internal/upload/ghcr_test.go
@@ -5,12 +5,34 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
+
+var errTestUpload = errors.New("test upload error")
+
+func TestNewGHCRReturnsGHCRUploader(t *testing.T) {
+	uploader := NewGHCR(GHCRConfig{Owner: "MeteorsLiu", Username: "MeteorsLiu", Token: "token"})
+	if uploader.Type() != "ghcr" {
+		t.Fatalf("Type = %q, want ghcr", uploader.Type())
+	}
+	got, ok := uploader.(ghcrUploader)
+	if !ok {
+		t.Fatalf("NewGHCR returned %T, want ghcrUploader", uploader)
+	}
+	if got.cfg.Owner != "MeteorsLiu" || got.cfg.Username != "MeteorsLiu" || got.cfg.Token != "token" {
+		t.Fatalf("config = %+v", got.cfg)
+	}
+	if got.writeIndex == nil {
+		t.Fatal("writeIndex is nil")
+	}
+}
 
 func TestChecksumResultReadsFromCurrentOffsetAndRestoresReader(t *testing.T) {
 	r := bytes.NewReader([]byte("prefixartifact-bytes"))
@@ -37,6 +59,24 @@ func TestChecksumResultReadsFromCurrentOffsetAndRestoresReader(t *testing.T) {
 	}
 	if offset != int64(len("prefix")) {
 		t.Fatalf("offset = %d, want %d", offset, len("prefix"))
+	}
+}
+
+func TestChecksumResultReportsReaderErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		r    io.ReadSeeker
+	}{
+		{name: "initial seek", r: seekErrorReader{}},
+		{name: "read", r: readErrorSeeker{}},
+		{name: "restore seek", r: &secondSeekErrorReader{Reader: bytes.NewReader([]byte("archive"))}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := checksumResult(tt.r); !errors.Is(err, errTestUpload) {
+				t.Fatalf("checksumResult error = %v, want %v", err, errTestUpload)
+			}
+		})
 	}
 }
 
@@ -132,6 +172,101 @@ func TestGHCRUploaderWritesOCIIndexWithArtifactLayer(t *testing.T) {
 	}
 }
 
+func TestGHCRUploaderWritesZstdLayerByDefaultingOwner(t *testing.T) {
+	writer := &recordingIndexWriter{}
+	uploader := ghcrUploader{
+		cfg:        GHCRConfig{Owner: "MeteorsLiu", Username: "MeteorsLiu", Token: "publish-token"},
+		writeIndex: writer.write,
+	}
+
+	_, err := uploader.Upload(context.Background(), bytes.NewReader([]byte("archive")), Options{
+		Name: "llar:test",
+		Type: "tar.zst",
+		Attrs: map[string]string{
+			"org.llar.matrix": "arm64-darwin",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if writer.ref != "ghcr.io/meteorsliu/llar:test" {
+		t.Fatalf("ref = %q", writer.ref)
+	}
+	manifest, err := writer.index.IndexManifest()
+	if err != nil {
+		t.Fatalf("IndexManifest: %v", err)
+	}
+	img, err := writer.index.Image(manifest.Manifests[0].Digest)
+	if err != nil {
+		t.Fatalf("Image: %v", err)
+	}
+	imgManifest, err := img.Manifest()
+	if err != nil {
+		t.Fatalf("Manifest: %v", err)
+	}
+	if got := imgManifest.Layers[0].MediaType; got != types.OCILayerZStd {
+		t.Fatalf("layer media type = %q, want %q", got, types.OCILayerZStd)
+	}
+}
+
+func TestGHCRUploaderReportsUploadErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		r    io.ReadSeeker
+		opts Options
+		u    ghcrUploader
+	}{
+		{
+			name: "invalid name",
+			r:    bytes.NewReader([]byte("archive")),
+			opts: Options{Name: "MeteorsLiu/llar"},
+			u:    ghcrUploader{cfg: GHCRConfig{Owner: "MeteorsLiu"}, writeIndex: (&recordingIndexWriter{}).write},
+		},
+		{
+			name: "unsupported archive type",
+			r:    bytes.NewReader([]byte("archive")),
+			opts: Options{Name: "MeteorsLiu/llar:test", Type: "zip"},
+			u:    ghcrUploader{cfg: GHCRConfig{Owner: "MeteorsLiu"}, writeIndex: (&recordingIndexWriter{}).write},
+		},
+		{
+			name: "initial seek",
+			r:    seekErrorReader{},
+			opts: Options{Name: "MeteorsLiu/llar:test"},
+			u:    ghcrUploader{cfg: GHCRConfig{Owner: "MeteorsLiu"}, writeIndex: (&recordingIndexWriter{}).write},
+		},
+		{
+			name: "read",
+			r:    readErrorSeeker{},
+			opts: Options{Name: "MeteorsLiu/llar:test"},
+			u:    ghcrUploader{cfg: GHCRConfig{Owner: "MeteorsLiu"}, writeIndex: (&recordingIndexWriter{}).write},
+		},
+		{
+			name: "restore seek",
+			r:    &secondSeekErrorReader{Reader: bytes.NewReader([]byte("archive"))},
+			opts: Options{Name: "MeteorsLiu/llar:test"},
+			u:    ghcrUploader{cfg: GHCRConfig{Owner: "MeteorsLiu"}, writeIndex: (&recordingIndexWriter{}).write},
+		},
+		{
+			name: "writer",
+			r:    bytes.NewReader([]byte("archive")),
+			opts: Options{Name: "MeteorsLiu/llar:test"},
+			u: ghcrUploader{
+				cfg: GHCRConfig{Owner: "MeteorsLiu"},
+				writeIndex: func(context.Context, string, v1.ImageIndex, string, string) error {
+					return errTestUpload
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.u.Upload(context.Background(), tt.r, tt.opts); err == nil {
+				t.Fatal("Upload error = nil, want error")
+			}
+		})
+	}
+}
+
 func TestGHCRUploaderAcceptsGitHubStyleOwnerCase(t *testing.T) {
 	writer := &recordingIndexWriter{}
 	uploader := ghcrUploader{
@@ -182,6 +317,91 @@ func TestGHCRUploaderPassesConfiguredUsernameToWriter(t *testing.T) {
 	}
 }
 
+func TestParseGHCRName(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawName string
+		owner   string
+		want    ghcrRef
+	}{
+		{
+			name:    "trims registry prefix",
+			rawName: "ghcr.io/MeteorsLiu/llar:test",
+			owner:   "MeteorsLiu",
+			want:    ghcrRef{repo: "meteorsliu/llar", tag: "test"},
+		},
+		{
+			name:    "adds owner",
+			rawName: "llar:test",
+			owner:   "/MeteorsLiu/",
+			want:    ghcrRef{repo: "meteorsliu/llar", tag: "test"},
+		},
+		{
+			name:    "keeps nested owner repo",
+			rawName: "MeteorsLiu/madler/zlib:v1.3.1",
+			owner:   "MeteorsLiu",
+			want:    ghcrRef{repo: "meteorsliu/madler/zlib", tag: "v1.3.1"},
+		},
+		{
+			name:    "allows empty owner",
+			rawName: "madler/zlib:v1.3.1",
+			want:    ghcrRef{repo: "madler/zlib", tag: "v1.3.1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGHCRName(tt.rawName, tt.owner)
+			if err != nil {
+				t.Fatalf("parseGHCRName: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseGHCRName = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGHCRNameRejectsInvalidNames(t *testing.T) {
+	tests := []struct {
+		rawName string
+		owner   string
+	}{
+		{rawName: ""},
+		{rawName: "MeteorsLiu/llar"},
+		{rawName: "MeteorsLiu/llar:"},
+		{rawName: ":test"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.rawName, func(t *testing.T) {
+			if _, err := parseGHCRName(tt.rawName, tt.owner); err == nil {
+				t.Fatal("parseGHCRName error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestLayerMediaTypeRejectsUnsupportedArchive(t *testing.T) {
+	if _, err := layerMediaType("zip"); err == nil || !strings.Contains(err.Error(), "unsupported ghcr archive type") {
+		t.Fatalf("layerMediaType error = %v, want unsupported archive type", err)
+	}
+}
+
+func TestWriteRemoteIndexValidatesReference(t *testing.T) {
+	err := writeRemoteIndex(context.Background(), "::not-a-tag", empty.Index, "MeteorsLiu", "token")
+	if err == nil {
+		t.Fatal("writeRemoteIndex error = nil, want invalid tag error")
+	}
+}
+
+func TestWriteRemoteIndexHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := writeRemoteIndex(ctx, "ghcr.io/meteorsliu/llar:test", empty.Index, "MeteorsLiu", "token")
+	if err == nil {
+		t.Fatal("writeRemoteIndex error = nil, want canceled context error")
+	}
+}
+
 func TestPlatformFromAttrsAllowsPartialPlatform(t *testing.T) {
 	got := platformFromAttrs(map[string]string{"os": "linux"})
 	if got == nil || got.OS != "linux" || got.Architecture != "" {
@@ -213,4 +433,37 @@ func (w *recordingIndexWriter) write(ctx context.Context, ref string, index v1.I
 	w.username = username
 	w.token = token
 	return nil
+}
+
+type seekErrorReader struct{}
+
+func (seekErrorReader) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (seekErrorReader) Seek(int64, int) (int64, error) {
+	return 0, errTestUpload
+}
+
+type readErrorSeeker struct{}
+
+func (readErrorSeeker) Read([]byte) (int, error) {
+	return 0, errTestUpload
+}
+
+func (readErrorSeeker) Seek(int64, int) (int64, error) {
+	return 0, nil
+}
+
+type secondSeekErrorReader struct {
+	*bytes.Reader
+	seeks int
+}
+
+func (r *secondSeekErrorReader) Seek(offset int64, whence int) (int64, error) {
+	r.seeks++
+	if r.seeks == 2 {
+		return 0, errTestUpload
+	}
+	return r.Reader.Seek(offset, whence)
 }

--- a/internal/upload/ghcr_test.go
+++ b/internal/upload/ghcr_test.go
@@ -157,6 +157,31 @@ func TestGHCRUploaderAcceptsGitHubStyleOwnerCase(t *testing.T) {
 	}
 }
 
+func TestGHCRUploaderPassesConfiguredUsernameToWriter(t *testing.T) {
+	writer := &recordingIndexWriter{}
+	uploader := ghcrUploader{
+		cfg: GHCRConfig{
+			Owner:    "MeteorsLiu",
+			Username: "MeteorsLiu",
+			Token:    "publish-token",
+		},
+		writeIndex: writer.write,
+	}
+
+	if _, err := uploader.Upload(context.Background(), bytes.NewReader([]byte("archive")), Options{
+		Name: "MeteorsLiu/llar:test",
+		Type: "tar.gz",
+	}); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if writer.username != "MeteorsLiu" {
+		t.Fatalf("username = %q, want MeteorsLiu", writer.username)
+	}
+	if writer.token != "publish-token" {
+		t.Fatalf("token = %q, want publish-token", writer.token)
+	}
+}
+
 func TestPlatformFromAttrsAllowsPartialPlatform(t *testing.T) {
 	got := platformFromAttrs(map[string]string{"os": "linux"})
 	if got == nil || got.OS != "linux" || got.Architecture != "" {
@@ -176,12 +201,16 @@ func TestPlatformFromAttrsAllowsPartialPlatform(t *testing.T) {
 }
 
 type recordingIndexWriter struct {
-	ref   string
-	index v1.ImageIndex
+	ref      string
+	index    v1.ImageIndex
+	username string
+	token    string
 }
 
 func (w *recordingIndexWriter) write(ctx context.Context, ref string, index v1.ImageIndex, username, token string) error {
 	w.ref = ref
 	w.index = index
+	w.username = username
+	w.token = token
 	return nil
 }

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -18,5 +18,6 @@ type Result struct {
 }
 
 type Uploader interface {
+	Type() string
 	Upload(ctx context.Context, r io.ReadSeeker, opts Options) (Result, error)
 }


### PR DESCRIPTION
## Summary
- pass the configured GHCR username to the registry writer instead of reusing the owner
- add upload tests using MeteorsLiu/llar test data

## Tests
- GOCACHE=/private/tmp/llar-go-cache go test -count=1 ./internal/upload