### PR TITLE
feat(make): add json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ llar make madler/zlib@v1.3.1
 # Build with verbose output
 llar make -v madler/zlib@v1.3.1
 
+# Print the build result as JSON
+llar make --json madler/zlib@v1.3.1
+
 # Build and export to a directory
 llar make -o ./output madler/zlib@v1.3.1
 
@@ -50,6 +53,7 @@ llar make ./madler/zlib@v1.3.1
 | Flag | Description |
 |------|-------------|
 | `-v, --verbose` | Enable verbose build output |
+| `-j, --json` | Print the build result as JSON |
 | `-o, --output <path>` | Output path (directory or `.zip` file) |
 
 ## How It Works

--- a/cmd/llar/internal/make.go
+++ b/cmd/llar/internal/make.go
@@ -24,10 +24,23 @@ import (
 
 var makeVerbose bool
 var makeOutput string
+var makeJSON bool
 
 type artifactMetadata struct {
 	Metadata string   `json:"metadata"`
 	Deps     []string `json:"deps,omitempty"`
+}
+
+type makeJSONDep struct {
+	Path    string `json:"path"`
+	Version string `json:"version"`
+}
+
+type makeJSONResult struct {
+	Path     string        `json:"path"`
+	Version  string        `json:"version"`
+	Deps     []makeJSONDep `json:"deps,omitempty"`
+	Metadata string        `json:"metadata"`
 }
 
 // newRemoteStore creates the remote formula store. Overridable for testing.
@@ -55,6 +68,7 @@ var makeCmd = &cobra.Command{
 func init() {
 	makeCmd.Flags().BoolVarP(&makeVerbose, "verbose", "v", false, "Enable verbose build output")
 	makeCmd.Flags().StringVarP(&makeOutput, "output", "o", "", "Output archive path (.zip file or .tar.gz file)")
+	makeCmd.Flags().BoolVarP(&makeJSON, "json", "j", false, "Print build result as JSON")
 	rootCmd.AddCommand(makeCmd)
 }
 
@@ -188,7 +202,22 @@ func buildModule(ctx context.Context, store repo.Store, modPath, version, matrix
 
 	if len(results) > 0 {
 		main := results[len(results)-1]
-		if main.Metadata != "" {
+		if makeJSON {
+			deps := artifactDeps(mods)
+			jsonDeps := make([]makeJSONDep, 0, len(deps))
+			for _, dep := range deps {
+				jsonDeps = append(jsonDeps, makeJSONDep{Path: dep.Path, Version: dep.Version})
+			}
+			out := makeJSONResult{
+				Path:     mods[0].Path,
+				Version:  mods[0].Version,
+				Deps:     jsonDeps,
+				Metadata: main.Metadata,
+			}
+			if err := json.NewEncoder(os.Stdout).Encode(out); err != nil {
+				return err
+			}
+		} else if main.Metadata != "" {
 			fmt.Println(main.Metadata)
 		}
 		if makeOutput != "" {

--- a/cmd/llar/internal/make_test.go
+++ b/cmd/llar/internal/make_test.go
@@ -338,8 +338,17 @@ func runMakeCmdStreams(t *testing.T, args ...string) (string, string, error) {
 	defer os.Chdir(origDir)
 
 	// Reset flags to defaults before each run
+	origMakeVerbose := makeVerbose
+	origMakeOutput := makeOutput
+	origMakeJSON := makeJSON
 	makeVerbose = true
 	makeOutput = ""
+	makeJSON = false
+	defer func() {
+		makeVerbose = origMakeVerbose
+		makeOutput = origMakeOutput
+		makeJSON = origMakeJSON
+	}()
 
 	// Set os.Args to match what Cobra will see, so resolveMatrixStr works.
 	origArgs := os.Args
@@ -757,6 +766,53 @@ func TestMakeLocal_BuildSuccess(t *testing.T) {
 	}
 }
 
+func TestMakeLocal_JSONOutput(t *testing.T) {
+	formulaDir := setupLocalFormulas(t)
+	withMockRemoteStore(t, repo.New(formulaDir, &noopVCSRepo{}))
+
+	origDir, _ := os.Getwd()
+	os.Chdir(filepath.Join(formulaDir, "test", "jsonroot"))
+	defer os.Chdir(origDir)
+
+	workspaceDir := isolatedWorkspaceDir(t)
+	matrixStr := computeMatrixStr()
+	prepopulateCache(t, workspaceDir, "test/jsondep", "1.2.3", matrixStr, "-ljsondep")
+	prepopulateCache(t, workspaceDir, "test/jsonroot", "1.0.0", matrixStr, "-ljsonroot")
+
+	out, err := runMakeCmd(t, "--json", "./@1.0.0")
+	if err != nil {
+		t.Fatalf("llar make --json failed: %v", err)
+	}
+
+	var got struct {
+		Path    string `json:"path"`
+		Version string `json:"version"`
+		Deps    []struct {
+			Path    string `json:"path"`
+			Version string `json:"version"`
+		} `json:"deps"`
+		Metadata string `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\nstdout:\n%s", err, out)
+	}
+	if got.Path != "test/jsonroot" {
+		t.Fatalf("path = %q, want %q", got.Path, "test/jsonroot")
+	}
+	if got.Version != "1.0.0" {
+		t.Fatalf("version = %q, want %q", got.Version, "1.0.0")
+	}
+	if got.Metadata != "-ljsonroot" {
+		t.Fatalf("metadata = %q, want %q", got.Metadata, "-ljsonroot")
+	}
+	if len(got.Deps) != 1 {
+		t.Fatalf("deps len = %d, want 1", len(got.Deps))
+	}
+	if got.Deps[0].Path != "test/jsondep" || got.Deps[0].Version != "1.2.3" {
+		t.Fatalf("deps[0] = %+v, want test/jsondep@1.2.3", got.Deps[0])
+	}
+}
+
 func TestMakeLocal_VerboseWritesBuildOutputToStderr(t *testing.T) {
 	formulaDir := setupLocalFormulas(t)
 	store := repo.New(formulaDir, &noopVCSRepo{})
@@ -809,9 +865,14 @@ func TestBuildModule_SilentSuccess(t *testing.T) {
 
 	// Silent mode: buildModule redirects os.Stdout to /dev/null,
 	// then restores before printing metadata
+	savedJSON := makeJSON
 	makeVerbose = false
 	makeOutput = ""
-	defer func() { makeVerbose = true }()
+	makeJSON = false
+	defer func() {
+		makeVerbose = true
+		makeJSON = savedJSON
+	}()
 
 	// Capture stdout to verify metadata output
 	origDir, _ := os.Getwd()

--- a/cmd/llar/internal/testdata/formulas/test/jsondep/1.2.3/Jsondep_llar.gox
+++ b/cmd/llar/internal/testdata/formulas/test/jsondep/1.2.3/Jsondep_llar.gox
@@ -1,0 +1,7 @@
+id "test/jsondep"
+
+fromVer "1.2.3"
+
+onBuild (ctx, proj, out) => {
+	out.setMetadata "-ljsondep"
+}

--- a/cmd/llar/internal/testdata/formulas/test/jsondep/versions.json
+++ b/cmd/llar/internal/testdata/formulas/test/jsondep/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "test/jsondep",
+	"deps": {}
+}

--- a/cmd/llar/internal/testdata/formulas/test/jsonroot/1.0.0/Jsonroot_llar.gox
+++ b/cmd/llar/internal/testdata/formulas/test/jsonroot/1.0.0/Jsonroot_llar.gox
@@ -1,0 +1,7 @@
+id "test/jsonroot"
+
+fromVer "1.0.0"
+
+onBuild (ctx, proj, out) => {
+	out.setMetadata "-ljsonroot"
+}

--- a/cmd/llar/internal/testdata/formulas/test/jsonroot/versions.json
+++ b/cmd/llar/internal/testdata/formulas/test/jsonroot/versions.json
@@ -1,0 +1,8 @@
+{
+	"path": "test/jsonroot",
+	"deps": {
+		"1.0.0": [
+			{"path": "test/jsondep", "version": "1.2.3"}
+		]
+	}
+}


### PR DESCRIPTION
Adds JSON output support for `llar make`.

The implementation includes:

- Adds `-j, --json` to the existing `make` Cobra command flags.
- Emits one root build result object with `path`, `version`, `deps`, and `metadata` fields.
- Adds `testdata/formulas` fixtures for the JSON make test instead of generating formula files inline.
- Documents `llar make --json` in `README.md`.

This keeps the new machine-readable output scoped to `llar make` while preserving the existing metadata-only output by default.