### PR TITLE
fix(modules): sanitize slash-containing source versions

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -273,7 +273,7 @@ func (b *Builder) Build(ctx context.Context, targets []*modules.Module) ([]Resul
 		// set those up uniformly regardless of cache state.
 
 		// TODO(MeteorsLiu): Source cache dir (belongs in the vcs layer)
-		tmpSourceDir, err := os.MkdirTemp("", fmt.Sprintf("source-%s-%s*", strings.ReplaceAll(mod.Path, "/", "-"), mod.Version))
+		tmpSourceDir, err := os.MkdirTemp("", fmt.Sprintf("source-%s-%s*", strings.ReplaceAll(mod.Path, "/", "-"), strings.ReplaceAll(mod.Version, "/", "-")))
 		if err != nil {
 			return Result{}, err
 		}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -569,6 +569,33 @@ func TestBuild_EmptyTargets(t *testing.T) {
 	}
 }
 
+func TestBuild_SlashInVersion(t *testing.T) {
+	store := setupTestStore(t)
+	b := setupBuilder(t, store, "amd64-linux")
+	wantRef := "refs/heads/feature/foo"
+	var gotRef string
+	sourceRepo := newMockRepo(filepath.Join(testSourceDir, "test/liba"))
+	sourceRepo.syncRef = &gotRef
+	b.newRepo = func(string) (vcs.Repo, error) {
+		return sourceRepo, nil
+	}
+	root := &modules.Module{
+		Formula: &internalformula.Formula{
+			OnBuild: func(*classfile.Context) {},
+		},
+		FS:      os.DirFS(testFormulaDir),
+		Path:    "test/liba",
+		Version: wantRef,
+	}
+
+	if _, err := b.Build(context.Background(), []*modules.Module{root}); err != nil {
+		t.Fatalf("Build() failed for slash-containing version: %v", err)
+	}
+	if gotRef != wantRef {
+		t.Fatalf("repo.Sync ref = %q, want %q", gotRef, wantRef)
+	}
+}
+
 func TestBuild_RecoversFormulaHookPanic(t *testing.T) {
 	wantErr := errors.New("hook failed")
 	tests := []struct {

--- a/internal/build/mock_test.go
+++ b/internal/build/mock_test.go
@@ -11,6 +11,7 @@ import (
 // mockRepo implements vcs.Repo interface for testing.
 type mockRepo struct {
 	testdataDir string
+	syncRef     *string
 }
 
 func (m *mockRepo) Tags(ctx context.Context) ([]string, error) {
@@ -26,6 +27,10 @@ func (m *mockRepo) At(ref, localDir string) fs.FS {
 }
 
 func (m *mockRepo) Sync(ctx context.Context, ref, path, destDir string) error {
+	if m.syncRef != nil {
+		*m.syncRef = ref
+	}
+
 	// Strip "github.com/" prefix if present
 	path = strings.TrimPrefix(path, "github.com/")
 

--- a/internal/modules/load.go
+++ b/internal/modules/load.go
@@ -319,7 +319,7 @@ func resolveDeps(mod module.Version, modFS fs.ReadFileFS, frla *formula.Formula,
 		// TODO(MeteorsLiu): Design source cache dir
 		// In the most common case, onRequire only read one file like CMakelist.txt, etc.
 		// So missing cache here is acceptable.
-		tmpSourceDir, err := os.MkdirTemp("", fmt.Sprintf("source-%s-%s*", strings.ReplaceAll(mod.Path, "/", "-"), mod.Version))
+		tmpSourceDir, err := os.MkdirTemp("", fmt.Sprintf("source-%s-%s*", strings.ReplaceAll(mod.Path, "/", "-"), strings.ReplaceAll(mod.Version, "/", "-")))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/modules/load_test.go
+++ b/internal/modules/load_test.go
@@ -187,6 +187,16 @@ func TestResolveDeps_WithOnRequire_EchoOnly_FallbackToVersionsJson(t *testing.T)
 	}
 }
 
+func TestResolveDeps_OnRequire_SlashInVersion(t *testing.T) {
+	frla := loadTestFormula(t, "testdata/load/towner/withreq", "towner/withreq", "1.0.0")
+	modFS := os.DirFS("testdata/load/towner/withreq").(fs.ReadFileFS)
+	mod := module.Version{Path: "towner/withreq", Version: "refs/heads/feature/foo"}
+
+	if _, err := resolveDeps(mod, modFS, frla, classfile.Matrix{}); err != nil {
+		t.Fatalf("resolveDeps failed for slash-containing version: %v", err)
+	}
+}
+
 func TestResolveDeps_WithOnRequire_AddsDeps(t *testing.T) {
 	frla := loadTestFormula(t, "testdata/load/towner/withdeps", "towner/withdeps", "1.0.0")
 	modFS := os.DirFS("testdata/load/towner/withdeps").(fs.ReadFileFS)


### PR DESCRIPTION
Allow source versions such as `refs/heads/feature/foo` to pass through module loading and building.

The implementation includes:

- Sanitize `/` only in temporary directory name patterns used by `resolveDeps` and `Builder.Build`.
- Preserve the original version string for `repo.At`, `repo.Sync`, dependency lookup, and error reporting.
- Add regressions for both module dependency resolution and the actual builder path, including ref preservation.
- Verify with `go test -short ./internal/build ./internal/modules/... -count=1`.

This removes the temporary-directory path-separator failure without changing the source ref semantics.