### PR TITLE
feat(cmd): include output directories in JSON results

### DIFF
--- a/cmd/llar/internal/doc.go
+++ b/cmd/llar/internal/doc.go
@@ -1,0 +1,25 @@
+// Package internal implements the llar command handlers.
+//
+// The --json flag causes make and install to print a module result in JSON
+// format. The JSON output corresponds to these Go types:
+//
+//	type moduleJSONResult struct {
+//		Path     string          `json:"path"`     // root module path
+//		Version  string          `json:"version"`  // root module version
+//		Dir      string          `json:"dir"`      // absolute root output directory
+//		Deps     []moduleJSONDep `json:"deps,omitempty"` // dependency artifacts
+//		Metadata string          `json:"metadata"` // build metadata for the root artifact
+//	}
+//
+//	type moduleJSONDep struct {
+//		Path    string `json:"path"`    // dependency module path
+//		Version string `json:"version"` // dependency module version
+//		Dir     string `json:"dir"`     // absolute dependency output directory
+//	}
+//
+// These fields are part of the llar command's public JSON API. Existing fields
+// must not be renamed, removed, or have their meaning changed. New fields may
+// be added when the output contract is extended. The encoder and the
+// JSON-specific tests live in module_output.go and module_output_test.go until
+// this contract is moved to a shared package.
+package internal

--- a/cmd/llar/internal/install.go
+++ b/cmd/llar/internal/install.go
@@ -142,7 +142,7 @@ func install(ctx context.Context, progress io.Writer, serviceURL, arg string, ma
 	matrixStr := matrix.Combinations()[0]
 
 	var rootResult moduleOutputResult
-	deps := make([]module.Version, 0, len(messages)-1)
+	deps := make([]moduleOutputDep, 0, len(messages)-1)
 	for _, message := range messages {
 		parsed, err := url.Parse(message.ID)
 		if err != nil {
@@ -184,7 +184,7 @@ func install(ctx context.Context, progress io.Writer, serviceURL, arg string, ma
 				OutputDir: installDir,
 			}
 		} else {
-			deps = append(deps, mod)
+			deps = append(deps, moduleOutputDep{Module: mod, OutputDir: installDir})
 		}
 	}
 	rootResult.Deps = deps

--- a/cmd/llar/internal/install_test.go
+++ b/cmd/llar/internal/install_test.go
@@ -174,6 +174,46 @@ func TestInstallCommand(t *testing.T) {
 	assertInstallFile(t, filepath.Join(directoryOutput, "include", "root.h"), "root")
 }
 
+func TestInstallCommandReturnsOutputPackagingError(t *testing.T) {
+	workspaceDir := isolatedWorkspaceDir(t)
+	query := url.Values{"arch": {runtime.GOARCH}, "os": {runtime.GOOS}}.Encode()
+	rootArchive := makeInstallArtifact(t, ".zip", "include/root.h", "root", "/build/root", "-lroot", nil)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/artifacts/test/root":
+			w.Header().Set("Content-Type", "application/x-cmdjsonl")
+			writeInstallCommand(t, w, "artifact", map[string]any{
+				"id": "test/root@v1.0.0?" + query, "type": "zip", "url": server.URL + "/root.zip",
+			})
+		case "/root.zip":
+			_, _ = w.Write(rootArchive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	redirectDefaultHTTPClient(t, server)
+
+	parent := filepath.Join(t.TempDir(), "parent")
+	if err := os.WriteFile(parent, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(parent, "root.zip")
+	_, _, err := runInstallCmd(t,
+		"--output", dest,
+		"--os", runtime.GOOS, "--arch", runtime.GOARCH,
+		"test/root",
+	)
+	if err == nil || !strings.Contains(err.Error(), "failed to write output") {
+		t.Fatalf("llar install error = %v, want output packaging error", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspaceDir, "test/root@v1.0.0-"+runtime.GOARCH+"-"+runtime.GOOS)); err != nil {
+		t.Fatalf("install cache missing after output error: %v", err)
+	}
+}
+
 func TestInstallCommandReturnsLlardError(t *testing.T) {
 	isolatedWorkspaceDir(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/llar/internal/install_test.go
+++ b/cmd/llar/internal/install_test.go
@@ -140,6 +140,10 @@ func TestInstallCommand(t *testing.T) {
 	if result.Path != "test/root" || result.Version != "v1.0.0" {
 		t.Fatalf("result = %+v, want test/root@v1.0.0", result)
 	}
+	installDir := filepath.Join(workspaceDir, "test/root@v1.0.0-testarch-testos|ON")
+	if result.Dir != installDir {
+		t.Fatalf("result dir = %q, want %q", result.Dir, installDir)
+	}
 	if _, err := os.Stat(output); err != nil {
 		t.Fatalf("output artifact: %v", err)
 	}
@@ -156,7 +160,6 @@ func TestInstallCommand(t *testing.T) {
 	if archiveInfo.Metadata != "-I"+filepath.Join(extracted, "include")+" -lroot" {
 		t.Fatalf("archive metadata = %+v", archiveInfo)
 	}
-	installDir := filepath.Join(workspaceDir, "test/root@v1.0.0-testarch-testos|ON")
 	assertInstallFile(t, filepath.Join(installDir, "include", "root.h"), "root")
 
 	directoryOutput := filepath.Join(t.TempDir(), "root-out")
@@ -312,7 +315,12 @@ func TestInstallDownloadsRootAndDependencies(t *testing.T) {
 	if result.Module != (module.Version{Path: "test/root", Version: "v1.0.0"}) {
 		t.Fatalf("result module = %+v", result.Module)
 	}
-	if len(result.Deps) != 1 || result.Deps[0] != (module.Version{Path: "test/dep", Version: "v1.2.3"}) {
+	depDir := filepath.Join(workspaceDir, fmt.Sprintf("test/dep@v1.2.3-%s", matrixStr))
+	rootDir := filepath.Join(workspaceDir, fmt.Sprintf("test/root@v1.0.0-%s", matrixStr))
+	if result.OutputDir != rootDir {
+		t.Fatalf("result output dir = %q, want %q", result.OutputDir, rootDir)
+	}
+	if len(result.Deps) != 1 || result.Deps[0].Module != (module.Version{Path: "test/dep", Version: "v1.2.3"}) || result.Deps[0].OutputDir != depDir {
 		t.Fatalf("result deps = %+v", result.Deps)
 	}
 	if result.Metadata != "-I"+filepath.Join(result.OutputDir, "include")+" -lroot" {
@@ -325,8 +333,6 @@ func TestInstallDownloadsRootAndDependencies(t *testing.T) {
 		t.Fatalf("llard artifact requests = %d, want one", artifactRequests)
 	}
 
-	depDir := filepath.Join(workspaceDir, fmt.Sprintf("test/dep@v1.2.3-%s", matrixStr))
-	rootDir := filepath.Join(workspaceDir, fmt.Sprintf("test/root@v1.0.0-%s", matrixStr))
 	assertInstallFile(t, filepath.Join(depDir, "lib", "libdep.a"), "dep")
 	assertInstallFile(t, filepath.Join(rootDir, "include", "root.h"), "root")
 	assertInstallCache(t, workspaceDir, "test/dep", "v1.2.3", matrixStr, "-L"+filepath.Join(depDir, "lib")+" -ldep")
@@ -355,8 +361,11 @@ func TestInstallDownloadsRootAndDependencies(t *testing.T) {
 	if err := json.Unmarshal(jsonOutput.Bytes(), &jsonResult); err != nil {
 		t.Fatal(err)
 	}
-	if jsonResult.Path != "test/root" || jsonResult.Version != "v1.0.0" || len(jsonResult.Deps) != 1 {
+	if jsonResult.Path != "test/root" || jsonResult.Version != "v1.0.0" || jsonResult.Dir != rootDir || len(jsonResult.Deps) != 1 {
 		t.Fatalf("JSON result = %+v", jsonResult)
+	}
+	if jsonResult.Deps[0].Path != "test/dep" || jsonResult.Deps[0].Version != "v1.2.3" || jsonResult.Deps[0].Dir != depDir {
+		t.Fatalf("JSON dependency = %+v", jsonResult.Deps[0])
 	}
 
 }
@@ -420,7 +429,7 @@ func TestInstallSkipsCachedArtifacts(t *testing.T) {
 	if result.Module != (module.Version{Path: "test/root", Version: "v1.0.0"}) {
 		t.Fatalf("result module = %+v", result.Module)
 	}
-	if len(result.Deps) != 1 || result.Deps[0] != (module.Version{Path: "test/dep", Version: "v1.2.3"}) {
+	if len(result.Deps) != 1 || result.Deps[0].Module != (module.Version{Path: "test/dep", Version: "v1.2.3"}) || result.Deps[0].OutputDir != depDir {
 		t.Fatalf("result deps = %+v", result.Deps)
 	}
 	if result.Metadata != "-I"+filepath.Join(result.OutputDir, "include")+" -lroot" {

--- a/cmd/llar/internal/make.go
+++ b/cmd/llar/internal/make.go
@@ -171,9 +171,35 @@ func buildModule(ctx context.Context, store repo.Store, modPath, version string,
 
 	if len(results) > 0 {
 		main := results[len(results)-1]
+		deps := artifactDeps(mods)
+		mainPath, err := module.EscapePath(mods[0].Path)
+		if err != nil {
+			return err
+		}
+		mainSuffix := fmt.Sprintf("%s@%s-%s", mainPath, mods[0].Version, matrixStr)
+		mainDir := filepath.Clean(main.OutputDir)
+		if !strings.HasSuffix(mainDir, mainSuffix) {
+			return fmt.Errorf("unexpected build output directory %q for %s@%s", mainDir, mods[0].Path, mods[0].Version)
+		}
+		workspaceDir := strings.TrimSuffix(mainDir, mainSuffix)
+		workspaceDir = strings.TrimSuffix(workspaceDir, string(filepath.Separator))
+		outputDeps := make([]moduleOutputDep, 0, len(deps))
+		for _, dep := range deps {
+			depPath, err := module.EscapePath(dep.Path)
+			if err != nil {
+				return err
+			}
+			outputDeps = append(outputDeps, moduleOutputDep{
+				Module: dep,
+				OutputDir: filepath.Join(
+					workspaceDir,
+					fmt.Sprintf("%s@%s-%s", depPath, dep.Version, matrixStr),
+				),
+			})
+		}
 		result := moduleOutputResult{
 			Module:    module.Version{Path: mods[0].Path, Version: mods[0].Version},
-			Deps:      artifactDeps(mods),
+			Deps:      outputDeps,
 			Metadata:  main.Metadata,
 			OutputDir: main.OutputDir,
 		}

--- a/cmd/llar/internal/make.go
+++ b/cmd/llar/internal/make.go
@@ -171,34 +171,15 @@ func buildModule(ctx context.Context, store repo.Store, modPath, version string,
 
 	if len(results) > 0 {
 		main := results[len(results)-1]
-		deps := artifactDeps(mods)
-		mainPath, err := module.EscapePath(mods[0].Path)
-		if err != nil {
-			return err
-		}
-		mainSuffix := fmt.Sprintf("%s@%s-%s", mainPath, mods[0].Version, matrixStr)
-		mainDir := filepath.Clean(main.OutputDir)
-		if !strings.HasSuffix(mainDir, mainSuffix) {
-			return fmt.Errorf("unexpected build output directory %q for %s@%s", mainDir, mods[0].Path, mods[0].Version)
-		}
-		workspaceDir := strings.TrimSuffix(mainDir, mainSuffix)
-		workspaceDir = strings.TrimSuffix(workspaceDir, string(filepath.Separator))
-		outputDeps := make([]moduleOutputDep, 0, len(deps))
-		for _, dep := range deps {
-			depPath, err := module.EscapePath(dep.Path)
-			if err != nil {
-				return err
-			}
+		outputDeps := make([]moduleOutputDep, 0, len(results)-1)
+		for _, result := range results[:len(results)-1] {
 			outputDeps = append(outputDeps, moduleOutputDep{
-				Module: dep,
-				OutputDir: filepath.Join(
-					workspaceDir,
-					fmt.Sprintf("%s@%s-%s", depPath, dep.Version, matrixStr),
-				),
+				Module:    result.Module,
+				OutputDir: result.OutputDir,
 			})
 		}
 		result := moduleOutputResult{
-			Module:    module.Version{Path: mods[0].Path, Version: mods[0].Version},
+			Module:    main.Module,
 			Deps:      outputDeps,
 			Metadata:  main.Metadata,
 			OutputDir: main.OutputDir,
@@ -241,19 +222,4 @@ func parseModuleArg(arg string) (pattern, version string, isLocal bool, err erro
 		}
 	}
 	return
-}
-
-func artifactDeps(mods []*modules.Module) []module.Version {
-	if len(mods) <= 1 {
-		return nil
-	}
-	deps := make([]module.Version, 0, len(mods)-1)
-	main := mods[0]
-	for _, mod := range mods[1:] {
-		if mod.Path == main.Path && mod.Version == main.Version {
-			continue
-		}
-		deps = append(deps, module.Version{Path: mod.Path, Version: mod.Version})
-	}
-	return deps
 }

--- a/cmd/llar/internal/make_test.go
+++ b/cmd/llar/internal/make_test.go
@@ -724,6 +724,53 @@ func TestMakeLocal_JSONOutput(t *testing.T) {
 	}
 }
 
+func TestBuildModuleReturnsOutputPackagingError(t *testing.T) {
+	formulaDir := setupLocalFormulas(t)
+	store := repo.New(formulaDir, &noopVCSRepo{})
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	sourceRoot := t.TempDir()
+	sourceRepo := filepath.Join(sourceRoot, "liba.git")
+	sourceWork := filepath.Join(sourceRoot, "work")
+	runGit("init", "--bare", sourceRepo)
+	runGit("init", sourceWork)
+	runGit("-C", sourceWork, "config", "user.email", "test@example.com")
+	runGit("-C", sourceWork, "config", "user.name", "llar test")
+	if err := os.WriteFile(filepath.Join(sourceWork, "source.txt"), []byte("source"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("-C", sourceWork, "add", "source.txt")
+	runGit("-C", sourceWork, "commit", "-m", "initial")
+	runGit("-C", sourceWork, "tag", "1.0.0")
+	runGit("-C", sourceWork, "push", sourceRepo, "1.0.0")
+
+	gitConfig := filepath.Join(t.TempDir(), "gitconfig")
+	runGit("config", "--file", gitConfig,
+		fmt.Sprintf("url.file://%s.insteadOf", sourceRepo),
+		"https://github.com/test/liba.git")
+	t.Setenv("GIT_CONFIG_GLOBAL", gitConfig)
+
+	blockedParent := filepath.Join(t.TempDir(), "parent")
+	if err := os.WriteFile(blockedParent, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	originalOutput := makeOutput
+	makeOutput = filepath.Join(blockedParent, "liba.zip")
+	t.Cleanup(func() { makeOutput = originalOutput })
+
+	_, _, restoreStreams := captureProcessStreams(t)
+	defer restoreStreams()
+	if err := buildModule(context.Background(), store, "test/liba", "1.0.0", computeMatrix(), false); err == nil || !strings.Contains(err.Error(), "failed to write output") {
+		t.Fatalf("buildModule() error = %v, want output packaging error", err)
+	}
+}
+
 func TestMakeLocal_VerboseWritesBuildOutputToStderr(t *testing.T) {
 	formulaDir := setupLocalFormulas(t)
 	store := repo.New(formulaDir, &noopVCSRepo{})

--- a/cmd/llar/internal/make_test.go
+++ b/cmd/llar/internal/make_test.go
@@ -688,9 +688,11 @@ func TestMakeLocal_JSONOutput(t *testing.T) {
 	var got struct {
 		Path    string `json:"path"`
 		Version string `json:"version"`
+		Dir     string `json:"dir"`
 		Deps    []struct {
 			Path    string `json:"path"`
 			Version string `json:"version"`
+			Dir     string `json:"dir"`
 		} `json:"deps"`
 		Metadata string `json:"metadata"`
 	}
@@ -703,6 +705,10 @@ func TestMakeLocal_JSONOutput(t *testing.T) {
 	if got.Version != "1.0.0" {
 		t.Fatalf("version = %q, want %q", got.Version, "1.0.0")
 	}
+	rootDir := filepath.Join(workspaceDir, fmt.Sprintf("test/jsonroot@1.0.0-%s", matrixStr))
+	if got.Dir != rootDir {
+		t.Fatalf("dir = %q, want %q", got.Dir, rootDir)
+	}
 	if got.Metadata != "-ljsonroot" {
 		t.Fatalf("metadata = %q, want %q", got.Metadata, "-ljsonroot")
 	}
@@ -711,6 +717,10 @@ func TestMakeLocal_JSONOutput(t *testing.T) {
 	}
 	if got.Deps[0].Path != "test/jsondep" || got.Deps[0].Version != "1.2.3" {
 		t.Fatalf("deps[0] = %+v, want test/jsondep@1.2.3", got.Deps[0])
+	}
+	depDir := filepath.Join(workspaceDir, fmt.Sprintf("test/jsondep@1.2.3-%s", matrixStr))
+	if got.Deps[0].Dir != depDir {
+		t.Fatalf("deps[0].dir = %q, want %q", got.Deps[0].Dir, depDir)
 	}
 }
 

--- a/cmd/llar/internal/make_test.go
+++ b/cmd/llar/internal/make_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -175,33 +174,6 @@ func TestNewRemoteStore(t *testing.T) {
 	}
 	if store == nil {
 		t.Fatal("newRemoteStore() returned nil")
-	}
-}
-
-func TestArtifactDepsSkipsMainModule(t *testing.T) {
-	mods := []*modules.Module{
-		{Path: "owner/main", Version: "v1.0.0"},
-		{Path: "dep/a", Version: "v1.1.0"},
-		{Path: "owner/main", Version: "v1.0.0"},
-		{Path: "dep/b", Version: "v1.2.0"},
-	}
-
-	got := artifactDeps(mods)
-	want := []module.Version{
-		{Path: "dep/a", Version: "v1.1.0"},
-		{Path: "dep/b", Version: "v1.2.0"},
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("artifactDeps = %+v, want %+v", got, want)
-	}
-}
-
-func TestArtifactDepsStandalone(t *testing.T) {
-	if got := artifactDeps(nil); got != nil {
-		t.Fatalf("artifactDeps(nil) = %+v, want nil", got)
-	}
-	if got := artifactDeps([]*modules.Module{{Path: "owner/main", Version: "v1.0.0"}}); got != nil {
-		t.Fatalf("artifactDeps(single) = %+v, want nil", got)
 	}
 }
 

--- a/cmd/llar/internal/module_output.go
+++ b/cmd/llar/internal/module_output.go
@@ -15,18 +15,25 @@ import (
 type moduleJSONDep struct {
 	Path    string `json:"path"`
 	Version string `json:"version"`
+	Dir     string `json:"dir"`
 }
 
 type moduleJSONResult struct {
 	Path     string          `json:"path"`
 	Version  string          `json:"version"`
+	Dir      string          `json:"dir"`
 	Deps     []moduleJSONDep `json:"deps,omitempty"`
 	Metadata string          `json:"metadata"`
 }
 
+type moduleOutputDep struct {
+	Module    module.Version
+	OutputDir string
+}
+
 type moduleOutputResult struct {
 	Module    module.Version
-	Deps      []module.Version
+	Deps      []moduleOutputDep
 	Metadata  string
 	OutputDir string
 }
@@ -42,11 +49,16 @@ func writeModuleResult(output io.Writer, result moduleOutputResult, jsonOutput b
 
 	deps := make([]moduleJSONDep, 0, len(result.Deps))
 	for _, dep := range result.Deps {
-		deps = append(deps, moduleJSONDep{Path: dep.Path, Version: dep.Version})
+		deps = append(deps, moduleJSONDep{
+			Path:    dep.Module.Path,
+			Version: dep.Module.Version,
+			Dir:     dep.OutputDir,
+		})
 	}
 	return json.NewEncoder(output).Encode(moduleJSONResult{
 		Path:     result.Module.Path,
 		Version:  result.Module.Version,
+		Dir:      result.OutputDir,
 		Deps:     deps,
 		Metadata: result.Metadata,
 	})
@@ -71,7 +83,11 @@ func writeModuleOutput(result moduleOutputResult, dest string) error {
 	if !strings.HasSuffix(dest, ".zip") && !strings.HasSuffix(dest, ".tar.gz") {
 		return os.CopyFS(dest, os.DirFS(result.OutputDir))
 	}
-	body, err := metadata.Encode(metadata.Info{Metadata: result.Metadata, Deps: result.Deps}, result.OutputDir)
+	deps := make([]module.Version, 0, len(result.Deps))
+	for _, dep := range result.Deps {
+		deps = append(deps, dep.Module)
+	}
+	body, err := metadata.Encode(metadata.Info{Metadata: result.Metadata, Deps: deps}, result.OutputDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/llar/internal/module_output_test.go
+++ b/cmd/llar/internal/module_output_test.go
@@ -64,3 +64,15 @@ func TestWriteModuleOutputArchiveIncludesDependencies(t *testing.T) {
 		t.Fatalf("metadata deps = %+v, want test/dep@v1.2.3", info.Deps)
 	}
 }
+
+func TestWriteModuleOutputReturnsStatError(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "parent")
+	if err := os.WriteFile(parent, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(parent, "root.tar.gz")
+	if err := writeModuleOutput(moduleOutputResult{}, dest); err == nil {
+		t.Fatal("writeModuleOutput() succeeded below a regular file")
+	}
+}

--- a/cmd/llar/internal/module_output_test.go
+++ b/cmd/llar/internal/module_output_test.go
@@ -1,0 +1,66 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goplus/llar/internal/artifact/archiver"
+	"github.com/goplus/llar/internal/metadata"
+	"github.com/goplus/llar/mod/module"
+)
+
+func TestWriteModuleResultJSONOmitsEmptyDeps(t *testing.T) {
+	result := moduleOutputResult{
+		Module:    module.Version{Path: "test/root", Version: "v1.0.0"},
+		OutputDir: "/workspace/test/root@v1.0.0-linux-amd64",
+		Metadata:  "-lroot",
+	}
+
+	var encoded bytes.Buffer
+	if err := writeModuleResult(&encoded, result, true); err != nil {
+		t.Fatal(err)
+	}
+	var output map[string]json.RawMessage
+	if err := json.Unmarshal(encoded.Bytes(), &output); err != nil {
+		t.Fatalf("JSON output is invalid: %v", err)
+	}
+	if _, ok := output["deps"]; ok {
+		t.Fatalf("JSON output contains deps for an empty dependency list: %s", encoded.Bytes())
+	}
+	if got := string(output["dir"]); got != `"/workspace/test/root@v1.0.0-linux-amd64"` {
+		t.Fatalf("JSON dir = %s", got)
+	}
+}
+
+func TestWriteModuleOutputArchiveIncludesDependencies(t *testing.T) {
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "root.a"), []byte("root"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := moduleOutputResult{
+		Module:    module.Version{Path: "test/root", Version: "v1.0.0"},
+		Deps:      []moduleOutputDep{{Module: module.Version{Path: "test/dep", Version: "v1.2.3"}}},
+		OutputDir: source,
+		Metadata:  "-lroot",
+	}
+	dest := filepath.Join(t.TempDir(), "root.tar.gz")
+	if err := writeModuleOutput(result, dest); err != nil {
+		t.Fatalf("writeModuleOutput() error = %v", err)
+	}
+
+	metadataBytes, err := archiver.Unpack(dest, t.TempDir())
+	if err != nil {
+		t.Fatalf("archiver.Unpack() error = %v", err)
+	}
+	info, err := metadata.Decode(metadataBytes, source)
+	if err != nil {
+		t.Fatalf("metadata.Decode() error = %v", err)
+	}
+	if len(info.Deps) != 1 || info.Deps[0] != (module.Version{Path: "test/dep", Version: "v1.2.3"}) {
+		t.Fatalf("metadata deps = %+v, want test/dep@v1.2.3", info.Deps)
+	}
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -32,6 +32,7 @@ type Builder struct {
 }
 
 type Result struct {
+	Module    module.Version
 	Metadata  string
 	OutputDir string
 }
@@ -265,7 +266,7 @@ func (b *Builder) Build(ctx context.Context, targets []*modules.Module) ([]Resul
 		// Fast path: cache hit and no OnTest to run. Skip source clone
 		// and OnBuild entirely.
 		if cacheHit && !testThisMod {
-			return Result{Metadata: entry.Metadata, OutputDir: installDir}, nil
+			return Result{Module: modVer, Metadata: entry.Metadata, OutputDir: installDir}, nil
 		}
 
 		// At this point we need to run OnBuild, OnTest, or both. All of
@@ -357,7 +358,7 @@ func (b *Builder) Build(ctx context.Context, targets []*modules.Module) ([]Resul
 			metadata = entry.Metadata
 		}
 
-		return Result{Metadata: metadata, OutputDir: installDir}, nil
+		return Result{Module: modVer, Metadata: metadata, OutputDir: installDir}, nil
 	}
 
 	var results []Result

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -820,6 +820,9 @@ func TestBuild_PrePopulatedCache(t *testing.T) {
 	if results[0].Metadata != "-lPRECACHED" {
 		t.Errorf("metadata = %q, want %q (from pre-populated cache)", results[0].Metadata, "-lPRECACHED")
 	}
+	if results[0].Module != main {
+		t.Errorf("module = %+v, want %+v", results[0].Module, main)
+	}
 }
 
 func TestBuild_CacheWrittenCorrectly(t *testing.T) {
@@ -827,7 +830,10 @@ func TestBuild_CacheWrittenCorrectly(t *testing.T) {
 	b := setupBuilder(t, store, "amd64-linux")
 
 	main := module.Version{Path: "test/liba", Version: "1.0.0"}
-	loadAndBuild(t, b, store, main)
+	results, _ := loadAndBuild(t, b, store, main)
+	if len(results) != 1 || results[0].Module != main {
+		t.Errorf("results = %+v, want module %s@%s", results, main.Path, main.Version)
+	}
 
 	// Load the cache file and verify its content
 	cache, err := b.loadCache("test/liba")


### PR DESCRIPTION
Include module and dependency output directories in JSON results from `llar make --json` and `llar install --json`.

The implementation includes:

- Add `dir` fields to root and dependency JSON records while preserving existing path, version, and metadata fields.
- Carry module identity and output directory together through `moduleOutputResult` while keeping archive metadata encoding on module versions.
- Resolve and reuse one `make` workspace directory for root and dependency artifact paths, including nested module paths.
- Cover `make` and `install` JSON directory values with focused tests.

Consumers can locate both root and dependency build artifacts directly from JSON without reconstructing workspace paths.