### PR TITLE
fix: preserve underscores in formula struct names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Classfile is a DSL (Domain Specific Language) mechanism in xgo that allows defin
    - `_cmp.gox` -> `CmpApp` class (formula/classfile.go)
 
 3. **Code Generation**: When a `.gox` file is processed:
-   - The filename prefix (before `_`) becomes the struct name
+   - The filename without the registered `_llar.gox` suffix becomes the struct name
    - Example: `hello_llar.gox` generates struct `hello` embedding `ModuleF`
    - A `MainEntry()` method is generated containing the DSL code
    - A `Main()` method calls `Gopt_ModuleF_Main(this)`
@@ -113,7 +113,7 @@ func main() {
 
 ### Key Points
 
-1. **Struct Name Derivation**: The struct name comes from `strings.Cut(filename, "_")` - the part before the first underscore
+1. **Struct Name Derivation**: The struct name comes from `strings.TrimSuffix(filename, "_llar.gox")`, preserving underscores in names such as `cpu_features`
 
 2. **Class Entry Point**: `Gopt_<ClassName>_Main` is the classfile entry point that:
    - Calls `MainEntry()` to execute DSL code

--- a/internal/formula/formula.go
+++ b/internal/formula/formula.go
@@ -77,7 +77,8 @@ type Formula struct {
 //	    new(hello).Main()
 //	}
 //
-// The struct name is derived from the filename prefix before "_" (e.g., "hello" from "hello_llar.gox").
+// The struct name is the filename without the registered "_llar.gox" suffix
+// (e.g., "cpu_features" from "cpu_features_llar.gox").
 // Calling Main() triggers Gopt_ModuleF_Main which invokes MainEntry() to populate the struct fields.
 func loadFS(fs fs.ReadFileFS, path string) (*Formula, error) {
 	// Formula types remain cached after loading, so later interpreters must not
@@ -119,12 +120,9 @@ func loadFS(fs fs.ReadFileFS, path string) (*Formula, error) {
 		return nil, err
 	}
 
-	// Extract struct name from filename: "hello_llar.gox" -> "hello"
+	// Extract struct name from filename: "cpu_features_llar.gox" -> "cpu_features"
 	// The classfile mechanism generates a struct with this name
-	structName, _, ok := strings.Cut(filepath.Base(path), "_")
-	if !ok {
-		return nil, fmt.Errorf("failed to load formula: file name is not valid: %s", path)
-	}
+	structName := strings.TrimSuffix(filepath.Base(path), "_llar.gox")
 
 	// Get the generated struct type from the interpreter
 	typ, ok := interp.GetType(structName)

--- a/internal/formula/formula_test.go
+++ b/internal/formula/formula_test.go
@@ -47,6 +47,17 @@ func TestLoadFS(t *testing.T) {
 		f.OnTest(&formulapkg.Context{})
 	})
 
+	t.Run("UnderscoreInStructName", func(t *testing.T) {
+		fsys := os.DirFS("testdata/formula").(fs.ReadFileFS)
+		f, err := LoadFS(fsys, "cpu_features_llar.gox")
+		if err != nil {
+			t.Fatalf("LoadFS failed: %v", err)
+		}
+		if f.ModPath != "google/cpu_features" {
+			t.Fatalf("ModPath = %q, want %q", f.ModPath, "google/cpu_features")
+		}
+	})
+
 	t.Run("NonExistentFile", func(t *testing.T) {
 		fsys := os.DirFS("testdata/formula").(fs.ReadFileFS)
 		_, err := LoadFS(fsys, "nonexistent.gox")

--- a/internal/formula/testdata/formula/cpu_features_llar.gox
+++ b/internal/formula/testdata/formula/cpu_features_llar.gox
@@ -1,0 +1,3 @@
+id "google/cpu_features"
+
+fromVer "v0.9.0"


### PR DESCRIPTION
## Summary

- derive the generated Formula struct name by trimming the full `_llar.gox` suffix
- preserve underscores in names such as `cpu_features`
- add a regression fixture and correct the classfile guidance

## Testing

- `go test -ldflags="-checklinkname=0" ./internal/formula -count=1`
- `go test -ldflags="-checklinkname=0" ./internal/modules -count=1`
- full `./...` reaches the existing `TestE2E_RealLibpngBuild` Clang 21 failure, reproduced unchanged on `goplus/main`