### PR TITLE
feat: expose selected version to formulas

### DIFF
--- a/formula/classfile.go
+++ b/formula/classfile.go
@@ -28,9 +28,10 @@ type ModuleF struct {
 	fOnTest    func(ctx *Context)
 	fFilter    func() bool
 
-	modPath    string
-	modFromVer string
-	target     Matrix
+	modPath       string
+	modFromVer    string
+	targetVersion string
+	target        Matrix
 }
 
 type Matrix struct {
@@ -39,8 +40,9 @@ type Matrix struct {
 	DefaultOptions map[string][]string
 }
 
-type matrixTarget struct {
-	m Matrix
+type formulaTarget struct {
+	version string
+	m       Matrix
 }
 
 // Combinations returns all cartesian product combinations of the matrix.
@@ -134,23 +136,32 @@ func (p *ModuleF) app() *gsh.App {
 	return &p.App
 }
 
-func (p *ModuleF) Target() matrixTarget {
-	return matrixTarget{m: Matrix{
-		Require: maps.Clone(p.target.Require),
-		Options: maps.Clone(p.target.Options),
-	}}
+func (p *ModuleF) Target() formulaTarget {
+	return formulaTarget{
+		version: p.targetVersion,
+		m: Matrix{
+			Require: maps.Clone(p.target.Require),
+			Options: maps.Clone(p.target.Options),
+		},
+	}
+}
+
+// Version backs the XGo auto-property `target.version`.
+// It is the original version or ref selected by LLAR.
+func (t formulaTarget) Version() string {
+	return t.version
 }
 
 // Require backs the XGo auto-property `target.require`.
 // In formula DSL, target.require["xxx"] maps to Target().Require()["xxx"].
-func (m matrixTarget) Require() map[string][]string {
-	return m.m.Require
+func (t formulaTarget) Require() map[string][]string {
+	return t.m.Require
 }
 
 // Options backs the XGo auto-property `target.options`.
 // In formula DSL, target.options["xxx"] maps to Target().Options()["xxx"].
-func (m matrixTarget) Options() map[string][]string {
-	return m.m.Options
+func (t formulaTarget) Options() map[string][]string {
+	return t.m.Options
 }
 
 // Defaults sets the formula's default option selections and initializes

--- a/formula/classfile_test.go
+++ b/formula/classfile_test.go
@@ -67,6 +67,7 @@ func TestGopt_ModuleF_Main(t *testing.T) {
 
 func TestModuleF_TargetReturnsMatrixCopy(t *testing.T) {
 	f := &ModuleF{}
+	f.targetVersion = "release/1.2.3"
 	f.target = Matrix{
 		Require: map[string][]string{
 			"os": {"linux"},
@@ -77,6 +78,9 @@ func TestModuleF_TargetReturnsMatrixCopy(t *testing.T) {
 	}
 
 	target := f.Target()
+	if got := target.Version(); got != "release/1.2.3" {
+		t.Fatalf("target.version = %q, want %q", got, "release/1.2.3")
+	}
 	target.Require()["os"] = []string{"darwin"}
 	target.Require()["arch"] = []string{"arm64"}
 	target.Options()["debug"] = []string{"on"}

--- a/internal/ixgo/pkg/github.com/goplus/llar/formula/export.go
+++ b/internal/ixgo/pkg/github.com/goplus/llar/formula/export.go
@@ -41,7 +41,7 @@ func init() {
 		},
 		TypedConsts: map[string]ixgo.TypedConst{},
 		UntypedConsts: map[string]ixgo.UntypedConst{
-			"XGoPackage": {"untyped bool", constant.MakeBool(bool(q.XGoPackage))},
+			"XGoPackage": {Typ: "untyped bool", Value: constant.MakeBool(bool(q.XGoPackage))},
 		},
 	})
 }

--- a/internal/modules/source.go
+++ b/internal/modules/source.go
@@ -86,7 +86,7 @@ func (m *formulaModule) at(version string) (*formula.Formula, error) {
 
 	if f, ok := m.formulas[fromVer]; ok {
 		clone := formula.Clone(f)
-		injectMatrix(clone, m.matrix)
+		injectTarget(clone, version, m.matrix)
 		return clone, nil
 	}
 	f, err := formula.LoadFS(m.fsys.(fs.ReadFileFS), formulaPath)
@@ -96,7 +96,7 @@ func (m *formulaModule) at(version string) (*formula.Formula, error) {
 	}
 	m.formulas[fromVer] = f
 	clone := formula.Clone(f)
-	injectMatrix(clone, m.matrix)
+	injectTarget(clone, version, m.matrix)
 	return clone, nil
 }
 

--- a/internal/modules/source_test.go
+++ b/internal/modules/source_test.go
@@ -147,7 +147,7 @@ func TestFormulaModule_AtReturnsIsolatedClasses(t *testing.T) {
 				want = true
 				wantDeps = 1
 			}
-			injectMatrix(f, classfile.Matrix{
+			injectTarget(f, "1.0.0", classfile.Matrix{
 				Require: map[string][]string{"os": {"linux"}},
 				Options: map[string][]string{"ssl": {ssl}},
 			})
@@ -172,6 +172,37 @@ func TestFormulaModule_AtReturnsIsolatedClasses(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
+	}
+}
+
+func TestFormulaModule_AtInjectsTargetVersion(t *testing.T) {
+	mod := newFormulaModule(os.DirFS("testdata/load/towner/targetversion"), "towner/targetversion", classfile.Matrix{})
+
+	for _, version := range []string{"1.0.0", "release/1.1.0"} {
+		f, err := mod.at(version)
+		if err != nil {
+			t.Fatalf("at(%q) failed: %v", version, err)
+		}
+		if !f.Filter() {
+			t.Fatalf("Filter() for %q = false, want true", version)
+		}
+
+		var deps classfile.ModuleDeps
+		f.OnRequire(&classfile.Project{}, &deps)
+		gotDeps := deps.Deps()
+		if len(gotDeps) != 1 || gotDeps[0].Version != version {
+			t.Fatalf("OnRequire deps for %q = %+v, want selected version", version, gotDeps)
+		}
+
+		ctx := &classfile.Context{}
+		f.OnBuild(ctx)
+		if got := ctx.Out.Metadata(); got != version {
+			t.Fatalf("OnBuild metadata for %q = %q, want selected version", version, got)
+		}
+	}
+
+	if len(mod.formulas) != 1 {
+		t.Fatalf("cached formulas = %d, want 1", len(mod.formulas))
 	}
 }
 

--- a/internal/modules/target.go
+++ b/internal/modules/target.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goplus/llar/internal/formula"
 )
 
-func injectMatrix(f *formula.Formula, matrix classfile.Matrix) {
+func injectTarget(f *formula.Formula, version string, matrix classfile.Matrix) {
 	formulaElem := reflect.ValueOf(f).Elem()
 	structElem := valueOf(formulaElem, "structElem").(reflect.Value)
 	target := valueOf(structElem, "target").(classfile.Matrix)
@@ -26,6 +26,7 @@ func injectMatrix(f *formula.Formula, matrix classfile.Matrix) {
 	for key, values := range matrix.Options {
 		effective.Options[key] = slices.Clone(values)
 	}
+	setValue(structElem, "targetVersion", version)
 	setValue(structElem, "target", effective)
 }
 

--- a/internal/modules/testdata/load/towner/targetversion/1.0.0/targetversion_llar.gox
+++ b/internal/modules/testdata/load/towner/targetversion/1.0.0/targetversion_llar.gox
@@ -1,0 +1,13 @@
+id "towner/targetversion"
+
+fromVer "1.0.0"
+
+filter => target.version != ""
+
+onRequire (proj, deps) => {
+	deps.require "towner/depmod", target.version
+}
+
+onBuild ctx => {
+	ctx.setMetadata target.version
+}

--- a/internal/modules/testdata/load/towner/targetversion/versions.json
+++ b/internal/modules/testdata/load/towner/targetversion/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "towner/targetversion",
+	"deps": {}
+}


### PR DESCRIPTION
## Summary

- expose LLARs selected raw version/ref as `target.version`
- inject the version into each Formula clone alongside the target matrix
- preserve tags, slash-containing refs, and commit hashes without normalization
- regenerate the Formula ixgo export with qexp from ixgo v1.1.6

## Testing

- `go test -ldflags="-checklinkname=0" ./formula -count=1`
- `go test -ldflags="-checklinkname=0" ./internal/ixgo -count=1`
- `go test -ldflags="-checklinkname=0" ./internal/formula -count=1`
- `go test -ldflags="-checklinkname=0" ./internal/modules -count=1`